### PR TITLE
Persist active roaster progress and show percent tooltip

### DIFF
--- a/src/main/java/growthcraft/cellar/block/entity/RoasterBlockEntity.java
+++ b/src/main/java/growthcraft/cellar/block/entity/RoasterBlockEntity.java
@@ -200,6 +200,9 @@ public class RoasterBlockEntity extends BlockEntity implements WorldlyContainer,
 
         roaster.processTimeTotal = Math.max(1, recipe.getRoastingLevel() * TICKS_PER_LEVEL);
         roaster.processTime++;
+        if (roaster.processTime == 1 || roaster.processTime % 40 == 0) {
+            roaster.setChanged();
+        }
         if (roaster.processTime >= roaster.processTimeTotal) {
             roaster.completeRecipe(recipe, batchSize);
             roaster.processTime = 0;

--- a/src/main/java/growthcraft/cellar/client/screen/RoasterScreen.java
+++ b/src/main/java/growthcraft/cellar/client/screen/RoasterScreen.java
@@ -48,6 +48,13 @@ public class RoasterScreen extends AbstractContainerScreen<RoasterMenu> {
     public void render(GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
         this.renderBackground(graphics, mouseX, mouseY, partialTick);
         super.render(graphics, mouseX, mouseY, partialTick);
+
+        int progressLeft = this.leftPos + PROGRESS_X;
+        int progressTop = this.topPos + PROGRESS_Y;
+        if (isMouseAbove(mouseX, mouseY, progressLeft, progressTop, PROGRESS_WIDTH, PROGRESS_HEIGHT)) {
+            graphics.renderTooltip(this.font, Component.translatable("growthcraft_cellar.tooltip.roaster.progress", this.menu.getPercentProgress()), mouseX, mouseY);
+        }
+
         this.renderTooltip(graphics, mouseX, mouseY);
     }
 
@@ -57,5 +64,9 @@ public class RoasterScreen extends AbstractContainerScreen<RoasterMenu> {
         Component levelText = Component.translatable("label.growthcraft_cellar.roaster_level", this.menu.getRoastingLevel());
         graphics.drawString(this.font, levelText, (this.imageWidth - this.font.width(levelText)) / 2, 20, 4210752, false);
         graphics.drawString(this.font, this.playerInventoryTitle, 8, this.imageHeight - 96 + 2, 4210752, false);
+    }
+
+    private static boolean isMouseAbove(int mouseX, int mouseY, int x, int y, int width, int height) {
+        return mouseX >= x && mouseX < x + width && mouseY >= y && mouseY < y + height;
     }
 }

--- a/src/main/java/growthcraft/cellar/menu/RoasterMenu.java
+++ b/src/main/java/growthcraft/cellar/menu/RoasterMenu.java
@@ -63,6 +63,12 @@ public class RoasterMenu extends AbstractContainerMenu {
         return Math.min(pixels, (data.get(0) * pixels) / total);
     }
 
+    public int getPercentProgress() {
+        int total = data.get(1);
+        if (total <= 0) return 0;
+        return Math.min(100, (data.get(0) * 100) / total);
+    }
+
     @Override
     public boolean stillValid(Player player) {
         return container.stillValid(player);

--- a/src/main/resources/assets/growthcraft_cellar/lang/en_us.json
+++ b/src/main/resources/assets/growthcraft_cellar/lang/en_us.json
@@ -128,7 +128,7 @@
   "item.growthcraft_cellar.yeast_lager": "Lager Yeast",
   "item.growthcraft_cellar.yeast_lager_ethereal": "Lager Yeast (Ethereal)",
   "item.growthcraft_cellar.cork_bark": "Cork Bark",
-  "growthcraft_cellar.tooltip.roaster.progress": "Roast Level %s (%d%%)",
+  "growthcraft_cellar.tooltip.roaster.progress": "Roasting %s%%",
   "growthcraft_cellar.tooltip.fermentation.progress": "Fermenting %s%%",
   "growthcraft_cellar.tooltip.fruit_press.progress": "Pressing %s%%",
   "growthcraft_cellar.tooltip.fermentation.yeast_warning": "Insufficient yeast.",


### PR DESCRIPTION
## Summary
- Persist active Roaster progress by marking the block entity dirty when roasting starts and every 40 ticks while processing.
- Add a hover tooltip over the Roaster progress arrow showing the current percentage.
- Reuse the existing Roaster progress translation key with a simpler percent-only message.

## Root cause
Roaster progress was saved to NBT, but active roasting did not mark the block entity dirty until completion/reset/item changes. A graceful save mid-roast could therefore reload older progress.

## Validation
- `./gradlew.bat compileJava -x createMinecraftArtifacts`
- `git diff --check`
- Manual test: started level 8 roasting, confirmed the progress tooltip appears, saved/quit, reloaded, and verified active roasting progress was preserved.

Closes #169