### PR TITLE
Add clone-pick support for rope and grape blocks

### DIFF
--- a/src/main/java/growthcraft/cellar/block/GrapeVineCropBlock.java
+++ b/src/main/java/growthcraft/cellar/block/GrapeVineCropBlock.java
@@ -6,7 +6,10 @@ import growthcraft.lib.block.GrowthcraftCropsRopeBlock;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.CollisionContext;
@@ -26,10 +29,12 @@ public class GrapeVineCropBlock extends GrowthcraftCropsRopeBlock {
             Block.box(6.0D, 0.0D, 6.0D, 10.0D, 16.0D, 10.0D)
     };
     private final Supplier<? extends GrapeVineLeavesCropBlock> leavesBlock;
+    private final Supplier<? extends Item> seedItem;
 
-    public GrapeVineCropBlock(Supplier<? extends GrapeVineLeavesCropBlock> leavesBlock) {
+    public GrapeVineCropBlock(Supplier<? extends GrapeVineLeavesCropBlock> leavesBlock, Supplier<? extends Item> seedItem) {
         super();
         this.leavesBlock = leavesBlock;
+        this.seedItem = seedItem;
     }
 
     @Override
@@ -44,6 +49,11 @@ public class GrapeVineCropBlock extends GrowthcraftCropsRopeBlock {
                 .setValue(EAST, false)
                 .setValue(SOUTH, false)
                 .setValue(WEST, false);
+    }
+
+    @Override
+    public ItemStack getCloneItemStack(LevelReader level, BlockPos pos, BlockState state) {
+        return new ItemStack(seedItem.get());
     }
 
     @Override

--- a/src/main/java/growthcraft/cellar/block/GrapeVineFruitBlock.java
+++ b/src/main/java/growthcraft/cellar/block/GrapeVineFruitBlock.java
@@ -66,6 +66,11 @@ public class GrapeVineFruitBlock extends GrowthcraftCropsRopeBlock {
     }
 
     @Override
+    public ItemStack getCloneItemStack(LevelReader level, BlockPos pos, BlockState state) {
+        return new ItemStack(fruitItem.get());
+    }
+
+    @Override
     protected void randomTick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
         if (!level.isAreaLoaded(pos, 1) || level.getRawBrightness(pos, 0) < 9 || isMaxAge(state)) {
             return;

--- a/src/main/java/growthcraft/cellar/block/GrapeVineLeavesCropBlock.java
+++ b/src/main/java/growthcraft/cellar/block/GrapeVineLeavesCropBlock.java
@@ -7,6 +7,8 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
@@ -21,10 +23,12 @@ import java.util.function.Supplier;
 public class GrapeVineLeavesCropBlock extends GrowthcraftCropsRopeBlock {
     private static final VoxelShape SHAPE = Block.box(0.0D, 0.0D, 0.0D, 16.0D, 16.0D, 16.0D);
     private final Supplier<? extends GrapeVineFruitBlock> fruitBlock;
+    private final Supplier<? extends Item> seedItem;
 
-    public GrapeVineLeavesCropBlock(Supplier<? extends GrapeVineFruitBlock> fruitBlock) {
+    public GrapeVineLeavesCropBlock(Supplier<? extends GrapeVineFruitBlock> fruitBlock, Supplier<? extends Item> seedItem) {
         super();
         this.fruitBlock = fruitBlock;
+        this.seedItem = seedItem;
     }
 
     @Override
@@ -35,6 +39,11 @@ public class GrapeVineLeavesCropBlock extends GrowthcraftCropsRopeBlock {
     @Override
     public boolean connectsAsRope() {
         return false;
+    }
+
+    @Override
+    public ItemStack getCloneItemStack(LevelReader level, BlockPos pos, BlockState state) {
+        return new ItemStack(seedItem.get());
     }
 
     @Override

--- a/src/main/java/growthcraft/cellar/init/GrowthcraftCellarBlocks.java
+++ b/src/main/java/growthcraft/cellar/init/GrowthcraftCellarBlocks.java
@@ -52,17 +52,17 @@ public final class GrowthcraftCellarBlocks {
     public static final DeferredBlock<GrapeVineFruitBlock> WHITE_GRAPE_VINE_FRUIT = BLOCKS.register(Reference.UnlocalizedName.Block.WHITE_GRAPE_VINE_FRUIT,
             () -> new GrapeVineFruitBlock(GrowthcraftCellarItems.GRAPE_WHITE));
     public static final DeferredBlock<GrapeVineLeavesCropBlock> PURPLE_GRAPE_VINE_LEAVES = BLOCKS.register(Reference.UnlocalizedName.Block.PURPLE_GRAPE_VINE_LEAVES,
-            () -> new GrapeVineLeavesCropBlock(PURPLE_GRAPE_VINE_FRUIT));
+            () -> new GrapeVineLeavesCropBlock(PURPLE_GRAPE_VINE_FRUIT, GrowthcraftCellarItems.GRAPE_SEEDS_PURPLE));
     public static final DeferredBlock<GrapeVineLeavesCropBlock> RED_GRAPE_VINE_LEAVES = BLOCKS.register(Reference.UnlocalizedName.Block.RED_GRAPE_VINE_LEAVES,
-            () -> new GrapeVineLeavesCropBlock(RED_GRAPE_VINE_FRUIT));
+            () -> new GrapeVineLeavesCropBlock(RED_GRAPE_VINE_FRUIT, GrowthcraftCellarItems.GRAPE_SEEDS_RED));
     public static final DeferredBlock<GrapeVineLeavesCropBlock> WHITE_GRAPE_VINE_LEAVES = BLOCKS.register(Reference.UnlocalizedName.Block.WHITE_GRAPE_VINE_LEAVES,
-            () -> new GrapeVineLeavesCropBlock(WHITE_GRAPE_VINE_FRUIT));
+            () -> new GrapeVineLeavesCropBlock(WHITE_GRAPE_VINE_FRUIT, GrowthcraftCellarItems.GRAPE_SEEDS_WHITE));
     public static final DeferredBlock<GrapeVineCropBlock> PURPLE_GRAPE_VINE = BLOCKS.register(Reference.UnlocalizedName.Block.PURPLE_GRAPE_VINE,
-            () -> new GrapeVineCropBlock(PURPLE_GRAPE_VINE_LEAVES));
+            () -> new GrapeVineCropBlock(PURPLE_GRAPE_VINE_LEAVES, GrowthcraftCellarItems.GRAPE_SEEDS_PURPLE));
     public static final DeferredBlock<GrapeVineCropBlock> RED_GRAPE_VINE = BLOCKS.register(Reference.UnlocalizedName.Block.RED_GRAPE_VINE,
-            () -> new GrapeVineCropBlock(RED_GRAPE_VINE_LEAVES));
+            () -> new GrapeVineCropBlock(RED_GRAPE_VINE_LEAVES, GrowthcraftCellarItems.GRAPE_SEEDS_RED));
     public static final DeferredBlock<GrapeVineCropBlock> WHITE_GRAPE_VINE = BLOCKS.register(Reference.UnlocalizedName.Block.WHITE_GRAPE_VINE,
-            () -> new GrapeVineCropBlock(WHITE_GRAPE_VINE_LEAVES));
+            () -> new GrapeVineCropBlock(WHITE_GRAPE_VINE_LEAVES, GrowthcraftCellarItems.GRAPE_SEEDS_WHITE));
     public static final DeferredBlock<HopsCropBlock> HOPS_VINE = BLOCKS.register(Reference.UnlocalizedName.Block.HOPS_VINE, HopsCropBlock::new);
 
     public static final DeferredBlock<Block> CORK_COASTER = BLOCKS.register(Reference.UnlocalizedName.Item.CORK_COASTER, () -> new CorkCoasterBlock());

--- a/src/main/java/growthcraft/core/block/RopeBlock.java
+++ b/src/main/java/growthcraft/core/block/RopeBlock.java
@@ -1,8 +1,10 @@
 package growthcraft.core.block;
 
 import growthcraft.lib.block.GrowthcraftCropsRopeBlock;
+import growthcraft.core.init.GrowthcraftItems;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.BlockGetter;
@@ -90,6 +92,11 @@ public class RopeBlock extends FenceBlock {
     public boolean canSurvive(BlockState state, LevelReader level, BlockPos pos) {
         // Same as FenceBlock (always can survive); ropes are not gravity-affected here.
         return true;
+    }
+
+    @Override
+    public ItemStack getCloneItemStack(LevelReader level, BlockPos pos, BlockState state) {
+        return new ItemStack(GrowthcraftItems.ROPE_LINEN.get());
     }
 
     @Override

--- a/src/main/java/growthcraft/core/block/RopeFenceBlock.java
+++ b/src/main/java/growthcraft/core/block/RopeFenceBlock.java
@@ -14,6 +14,7 @@ import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.FenceBlock;
@@ -108,6 +109,11 @@ public class RopeFenceBlock extends FenceBlock {
             drops.add(new ItemStack(vanillaFence));
         }
         return drops;
+    }
+
+    @Override
+    public ItemStack getCloneItemStack(LevelReader level, BlockPos pos, BlockState state) {
+        return new ItemStack(GrowthcraftItems.ROPE_LINEN.get());
     }
 
     public static Block getVanillaFenceFor(Block ropeFenceBlock) {


### PR DESCRIPTION
## Summary
- Add clone-pick results for linen rope and roped fence overlay blocks.
- Add clone-pick results for grape vine stems and leaves so they return the matching grape seeds.
- Add clone-pick results for grape fruit clusters so they return the matching grape item.

## Root cause
Several rope and grape blocks are world/internal blocks without useful block items, so creative middle-click either returned nothing useful or did not provide the item a player would need to recreate the block.

## Validation
- `./gradlew.bat compileJava -x createMinecraftArtifacts`
- `git diff --check`
- Manual test: clone-picked rope blocks and roped fences and confirmed they return linen rope.
- Manual test: clone-picked grape vine stems/leaves and confirmed they return the matching grape seeds.
- Manual test: confirmed existing hops clone-pick still returns hops seeds.

Closes #134