### PR TITLE
Connect ropes to grape vine leaves

### DIFF
--- a/src/main/java/growthcraft/cellar/block/GrapeVineLeavesCropBlock.java
+++ b/src/main/java/growthcraft/cellar/block/GrapeVineLeavesCropBlock.java
@@ -38,7 +38,7 @@ public class GrapeVineLeavesCropBlock extends GrowthcraftCropsRopeBlock {
 
     @Override
     public boolean connectsAsRope() {
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Allow grape vine leaf blocks to act as visual rope connection endpoints.
- Fix rope knots and roped fences so their rope overlay extends toward grape vine leaves.

## Root cause
Grape vine leaves inherited the crop/rope connection system, but overrode `connectsAsRope()` to return `false`. That made nearby rope blocks and roped fences refuse to render connections toward grape leaves even though grape leaves could still visually connect back to rope-supported structures.

## Validation
- `./gradlew.bat compileJava -x createMinecraftArtifacts`
- `./gradlew.bat test -x createMinecraftArtifacts`
- `git diff --check`
- Manual in-game testing confirmed ropes connect to grape vines and hops as expected.

closes #133