### PR TITLE
Add condensed milk dessert recipes

### DIFF
--- a/src/generated/resources/data/growthcraft_milk/advancement/recipes/food/condensed_milk_butter_cake.json
+++ b/src/generated/resources/data/growthcraft_milk/advancement/recipes/food/condensed_milk_butter_cake.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_condensed_milk_bucket": {
+      "conditions": {
+        "items": [
+          {
+            "items": "growthcraft_milk:condensed_milk_fluid_bucket"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "growthcraft_milk:condensed_milk_butter_cake"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_condensed_milk_bucket"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "growthcraft_milk:condensed_milk_butter_cake"
+    ]
+  }
+}

--- a/src/generated/resources/data/growthcraft_milk/advancement/recipes/food/condensed_milk_butter_cookies.json
+++ b/src/generated/resources/data/growthcraft_milk/advancement/recipes/food/condensed_milk_butter_cookies.json
@@ -1,0 +1,54 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_butter": {
+      "conditions": {
+        "items": [
+          {
+            "items": "#c:foods/butter"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_cocoa_beans": {
+      "conditions": {
+        "items": [
+          {
+            "items": "minecraft:cocoa_beans"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_condensed_milk_bucket": {
+      "conditions": {
+        "items": [
+          {
+            "items": "growthcraft_milk:condensed_milk_fluid_bucket"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "growthcraft_milk:condensed_milk_butter_cookies"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_condensed_milk_bucket",
+      "has_butter",
+      "has_cocoa_beans"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "growthcraft_milk:condensed_milk_butter_cookies"
+    ]
+  }
+}

--- a/src/generated/resources/data/growthcraft_milk/advancement/recipes/food/ice_cream_apple_from_condensed_milk.json
+++ b/src/generated/resources/data/growthcraft_milk/advancement/recipes/food/ice_cream_apple_from_condensed_milk.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_condensed_milk_bucket": {
+      "conditions": {
+        "items": [
+          {
+            "items": "growthcraft_milk:condensed_milk_fluid_bucket"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "growthcraft_milk:ice_cream_apple_from_condensed_milk"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_condensed_milk_bucket"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "growthcraft_milk:ice_cream_apple_from_condensed_milk"
+    ]
+  }
+}

--- a/src/generated/resources/data/growthcraft_milk/advancement/recipes/food/ice_cream_chocolate_from_condensed_milk.json
+++ b/src/generated/resources/data/growthcraft_milk/advancement/recipes/food/ice_cream_chocolate_from_condensed_milk.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_condensed_milk_bucket": {
+      "conditions": {
+        "items": [
+          {
+            "items": "growthcraft_milk:condensed_milk_fluid_bucket"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "growthcraft_milk:ice_cream_chocolate_from_condensed_milk"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_condensed_milk_bucket"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "growthcraft_milk:ice_cream_chocolate_from_condensed_milk"
+    ]
+  }
+}

--- a/src/generated/resources/data/growthcraft_milk/advancement/recipes/food/ice_cream_grape_purple_from_condensed_milk.json
+++ b/src/generated/resources/data/growthcraft_milk/advancement/recipes/food/ice_cream_grape_purple_from_condensed_milk.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_condensed_milk_bucket": {
+      "conditions": {
+        "items": [
+          {
+            "items": "growthcraft_milk:condensed_milk_fluid_bucket"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "growthcraft_milk:ice_cream_grape_purple_from_condensed_milk"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_condensed_milk_bucket"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "growthcraft_milk:ice_cream_grape_purple_from_condensed_milk"
+    ]
+  }
+}

--- a/src/generated/resources/data/growthcraft_milk/advancement/recipes/food/ice_cream_grape_red_from_condensed_milk.json
+++ b/src/generated/resources/data/growthcraft_milk/advancement/recipes/food/ice_cream_grape_red_from_condensed_milk.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_condensed_milk_bucket": {
+      "conditions": {
+        "items": [
+          {
+            "items": "growthcraft_milk:condensed_milk_fluid_bucket"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "growthcraft_milk:ice_cream_grape_red_from_condensed_milk"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_condensed_milk_bucket"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "growthcraft_milk:ice_cream_grape_red_from_condensed_milk"
+    ]
+  }
+}

--- a/src/generated/resources/data/growthcraft_milk/advancement/recipes/food/ice_cream_grape_white_from_condensed_milk.json
+++ b/src/generated/resources/data/growthcraft_milk/advancement/recipes/food/ice_cream_grape_white_from_condensed_milk.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_condensed_milk_bucket": {
+      "conditions": {
+        "items": [
+          {
+            "items": "growthcraft_milk:condensed_milk_fluid_bucket"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "growthcraft_milk:ice_cream_grape_white_from_condensed_milk"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_condensed_milk_bucket"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "growthcraft_milk:ice_cream_grape_white_from_condensed_milk"
+    ]
+  }
+}

--- a/src/generated/resources/data/growthcraft_milk/advancement/recipes/food/ice_cream_honey_from_condensed_milk.json
+++ b/src/generated/resources/data/growthcraft_milk/advancement/recipes/food/ice_cream_honey_from_condensed_milk.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_condensed_milk_bucket": {
+      "conditions": {
+        "items": [
+          {
+            "items": "growthcraft_milk:condensed_milk_fluid_bucket"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "growthcraft_milk:ice_cream_honey_from_condensed_milk"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_condensed_milk_bucket"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "growthcraft_milk:ice_cream_honey_from_condensed_milk"
+    ]
+  }
+}

--- a/src/generated/resources/data/growthcraft_milk/advancement/recipes/food/ice_cream_pumpkin_from_condensed_milk.json
+++ b/src/generated/resources/data/growthcraft_milk/advancement/recipes/food/ice_cream_pumpkin_from_condensed_milk.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_condensed_milk_bucket": {
+      "conditions": {
+        "items": [
+          {
+            "items": "growthcraft_milk:condensed_milk_fluid_bucket"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "growthcraft_milk:ice_cream_pumpkin_from_condensed_milk"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_condensed_milk_bucket"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "growthcraft_milk:ice_cream_pumpkin_from_condensed_milk"
+    ]
+  }
+}

--- a/src/generated/resources/data/growthcraft_milk/advancement/recipes/food/ice_cream_watermelon_from_condensed_milk.json
+++ b/src/generated/resources/data/growthcraft_milk/advancement/recipes/food/ice_cream_watermelon_from_condensed_milk.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_condensed_milk_bucket": {
+      "conditions": {
+        "items": [
+          {
+            "items": "growthcraft_milk:condensed_milk_fluid_bucket"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "growthcraft_milk:ice_cream_watermelon_from_condensed_milk"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_condensed_milk_bucket"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "growthcraft_milk:ice_cream_watermelon_from_condensed_milk"
+    ]
+  }
+}

--- a/src/generated/resources/data/growthcraft_milk/recipe/condensed_milk_butter_cake.json
+++ b/src/generated/resources/data/growthcraft_milk/recipe/condensed_milk_butter_cake.json
@@ -1,0 +1,28 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "group": "growthcraft_milk",
+  "key": {
+    "B": {
+      "tag": "c:foods/butter"
+    },
+    "C": {
+      "item": "growthcraft_milk:condensed_milk_fluid_bucket"
+    },
+    "E": {
+      "item": "minecraft:egg"
+    },
+    "W": {
+      "item": "minecraft:wheat"
+    }
+  },
+  "pattern": [
+    "CBC",
+    " E ",
+    "WWW"
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:cake"
+  }
+}

--- a/src/generated/resources/data/growthcraft_milk/recipe/condensed_milk_butter_cookies.json
+++ b/src/generated/resources/data/growthcraft_milk/recipe/condensed_milk_butter_cookies.json
@@ -1,0 +1,26 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "growthcraft_milk",
+  "ingredients": [
+    {
+      "item": "minecraft:wheat"
+    },
+    {
+      "item": "minecraft:wheat"
+    },
+    {
+      "tag": "c:foods/butter"
+    },
+    {
+      "item": "minecraft:cocoa_beans"
+    },
+    {
+      "item": "growthcraft_milk:condensed_milk_fluid_bucket"
+    }
+  ],
+  "result": {
+    "count": 24,
+    "id": "minecraft:cookie"
+  }
+}

--- a/src/generated/resources/data/growthcraft_milk/recipe/ice_cream_apple_from_condensed_milk.json
+++ b/src/generated/resources/data/growthcraft_milk/recipe/ice_cream_apple_from_condensed_milk.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "growthcraft_milk",
+  "ingredients": [
+    {
+      "item": "growthcraft_milk:condensed_milk_fluid_bucket"
+    },
+    {
+      "item": "minecraft:apple"
+    },
+    {
+      "item": "minecraft:bowl"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "growthcraft_milk:ice_cream_apple"
+  }
+}

--- a/src/generated/resources/data/growthcraft_milk/recipe/ice_cream_chocolate_from_condensed_milk.json
+++ b/src/generated/resources/data/growthcraft_milk/recipe/ice_cream_chocolate_from_condensed_milk.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "growthcraft_milk",
+  "ingredients": [
+    {
+      "item": "growthcraft_milk:condensed_milk_fluid_bucket"
+    },
+    {
+      "item": "minecraft:cocoa_beans"
+    },
+    {
+      "item": "minecraft:bowl"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "growthcraft_milk:ice_cream_chocolate"
+  }
+}

--- a/src/generated/resources/data/growthcraft_milk/recipe/ice_cream_grape_purple_from_condensed_milk.json
+++ b/src/generated/resources/data/growthcraft_milk/recipe/ice_cream_grape_purple_from_condensed_milk.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "growthcraft_milk",
+  "ingredients": [
+    {
+      "item": "growthcraft_milk:condensed_milk_fluid_bucket"
+    },
+    {
+      "item": "growthcraft_cellar:grape_purple"
+    },
+    {
+      "item": "minecraft:bowl"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "growthcraft_milk:ice_cream_grape_purple"
+  }
+}

--- a/src/generated/resources/data/growthcraft_milk/recipe/ice_cream_grape_red_from_condensed_milk.json
+++ b/src/generated/resources/data/growthcraft_milk/recipe/ice_cream_grape_red_from_condensed_milk.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "growthcraft_milk",
+  "ingredients": [
+    {
+      "item": "growthcraft_milk:condensed_milk_fluid_bucket"
+    },
+    {
+      "item": "growthcraft_cellar:grape_red"
+    },
+    {
+      "item": "minecraft:bowl"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "growthcraft_milk:ice_cream_grape_red"
+  }
+}

--- a/src/generated/resources/data/growthcraft_milk/recipe/ice_cream_grape_white_from_condensed_milk.json
+++ b/src/generated/resources/data/growthcraft_milk/recipe/ice_cream_grape_white_from_condensed_milk.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "growthcraft_milk",
+  "ingredients": [
+    {
+      "item": "growthcraft_milk:condensed_milk_fluid_bucket"
+    },
+    {
+      "item": "growthcraft_cellar:grape_white"
+    },
+    {
+      "item": "minecraft:bowl"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "growthcraft_milk:ice_cream_grape_white"
+  }
+}

--- a/src/generated/resources/data/growthcraft_milk/recipe/ice_cream_honey_from_condensed_milk.json
+++ b/src/generated/resources/data/growthcraft_milk/recipe/ice_cream_honey_from_condensed_milk.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "growthcraft_milk",
+  "ingredients": [
+    {
+      "item": "growthcraft_milk:condensed_milk_fluid_bucket"
+    },
+    {
+      "item": "minecraft:honeycomb"
+    },
+    {
+      "item": "minecraft:bowl"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "growthcraft_milk:ice_cream_honey"
+  }
+}

--- a/src/generated/resources/data/growthcraft_milk/recipe/ice_cream_pumpkin_from_condensed_milk.json
+++ b/src/generated/resources/data/growthcraft_milk/recipe/ice_cream_pumpkin_from_condensed_milk.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "growthcraft_milk",
+  "ingredients": [
+    {
+      "item": "growthcraft_milk:condensed_milk_fluid_bucket"
+    },
+    {
+      "item": "minecraft:pumpkin"
+    },
+    {
+      "item": "minecraft:bowl"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "growthcraft_milk:ice_cream_pumpkin"
+  }
+}

--- a/src/generated/resources/data/growthcraft_milk/recipe/ice_cream_watermelon_from_condensed_milk.json
+++ b/src/generated/resources/data/growthcraft_milk/recipe/ice_cream_watermelon_from_condensed_milk.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "growthcraft_milk",
+  "ingredients": [
+    {
+      "item": "growthcraft_milk:condensed_milk_fluid_bucket"
+    },
+    {
+      "item": "minecraft:melon_slice"
+    },
+    {
+      "item": "minecraft:bowl"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "growthcraft_milk:ice_cream_watermelon"
+  }
+}

--- a/src/main/java/growthcraft/core/data/recipe/GrowthcraftRecipeProvider.java
+++ b/src/main/java/growthcraft/core/data/recipe/GrowthcraftRecipeProvider.java
@@ -8,6 +8,7 @@ import growthcraft.apiary.init.GrowthcraftApiaryTags;
 import growthcraft.bamboo.init.GrowthcraftBambooItems;
 import growthcraft.cellar.init.GrowthcraftCellarItems;
 import growthcraft.core.init.GrowthcraftItems;
+import growthcraft.milk.init.GrowthcraftMilkFluids;
 import growthcraft.milk.init.GrowthcraftMilkItems;
 import growthcraft.milk.init.GrowthcraftMilkTags;
 import net.minecraft.core.HolderLookup;
@@ -490,6 +491,18 @@ public class GrowthcraftRecipeProvider extends RecipeProvider {
                 .unlockedBy("has_milk_bucket", has(GrowthcraftMilkTags.Items.TAG_MILK_BUCKETS))
                 .save(output, ResourceLocation.fromNamespaceAndPath(growthcraft.milk.config.Reference.MODID, "butter_cake"));
 
+        ShapedRecipeBuilder.shaped(RecipeCategory.FOOD, Items.CAKE)
+                .pattern("CBC")
+                .pattern(" E ")
+                .pattern("WWW")
+                .define('C', GrowthcraftMilkFluids.CONDENSED_MILK.bucket.get())
+                .define('B', butter)
+                .define('E', Items.EGG)
+                .define('W', Items.WHEAT)
+                .group("growthcraft_milk")
+                .unlockedBy("has_condensed_milk_bucket", has(GrowthcraftMilkFluids.CONDENSED_MILK.bucket.get()))
+                .save(output, ResourceLocation.fromNamespaceAndPath(growthcraft.milk.config.Reference.MODID, "condensed_milk_butter_cake"));
+
         ShapedRecipeBuilder.shaped(RecipeCategory.FOOD, Items.COOKIE, 12)
                 .pattern("WBW")
                 .pattern(" C ")
@@ -500,6 +513,17 @@ public class GrowthcraftRecipeProvider extends RecipeProvider {
                 .unlockedBy("has_butter", has(butter))
                 .unlockedBy(getHasName(Items.COCOA_BEANS), has(Items.COCOA_BEANS))
                 .save(output, ResourceLocation.fromNamespaceAndPath(growthcraft.milk.config.Reference.MODID, "butter_cookies"));
+
+        ShapelessRecipeBuilder.shapeless(RecipeCategory.FOOD, Items.COOKIE, 24)
+                .requires(Items.WHEAT, 2)
+                .requires(butter)
+                .requires(Items.COCOA_BEANS)
+                .requires(GrowthcraftMilkFluids.CONDENSED_MILK.bucket.get())
+                .group("growthcraft_milk")
+                .unlockedBy("has_condensed_milk_bucket", has(GrowthcraftMilkFluids.CONDENSED_MILK.bucket.get()))
+                .unlockedBy("has_butter", has(butter))
+                .unlockedBy(getHasName(Items.COCOA_BEANS), has(Items.COCOA_BEANS))
+                .save(output, ResourceLocation.fromNamespaceAndPath(growthcraft.milk.config.Reference.MODID, "condensed_milk_butter_cookies"));
     }
 
     private static void addMilkBowlFoodRecipes(RecipeOutput output) {
@@ -511,6 +535,15 @@ public class GrowthcraftRecipeProvider extends RecipeProvider {
         addIceCreamRecipe(output, GrowthcraftMilkItems.ICE_CREAM_HONEY.get(), Items.HONEYCOMB, growthcraft.milk.config.Reference.UnlocalizedName.ICE_CREAM_HONEY);
         addIceCreamRecipe(output, GrowthcraftMilkItems.ICE_CREAM_PUMPKIN.get(), Items.PUMPKIN, growthcraft.milk.config.Reference.UnlocalizedName.ICE_CREAM_PUMPKIN);
         addIceCreamRecipe(output, GrowthcraftMilkItems.ICE_CREAM_WATERMELON.get(), Items.MELON_SLICE, growthcraft.milk.config.Reference.UnlocalizedName.ICE_CREAM_WATERMELON);
+
+        addCondensedMilkIceCreamRecipe(output, GrowthcraftMilkItems.ICE_CREAM_APPLE.get(), Items.APPLE, growthcraft.milk.config.Reference.UnlocalizedName.ICE_CREAM_APPLE);
+        addCondensedMilkIceCreamRecipe(output, GrowthcraftMilkItems.ICE_CREAM_CHOCOLATE.get(), Items.COCOA_BEANS, growthcraft.milk.config.Reference.UnlocalizedName.ICE_CREAM_CHOCOLATE);
+        addCondensedMilkIceCreamRecipe(output, GrowthcraftMilkItems.ICE_CREAM_GRAPE_PURPLE.get(), GrowthcraftCellarItems.GRAPE_PURPLE.get(), growthcraft.milk.config.Reference.UnlocalizedName.ICE_CREAM_GRAPE_PURPLE);
+        addCondensedMilkIceCreamRecipe(output, GrowthcraftMilkItems.ICE_CREAM_GRAPE_RED.get(), GrowthcraftCellarItems.GRAPE_RED.get(), growthcraft.milk.config.Reference.UnlocalizedName.ICE_CREAM_GRAPE_RED);
+        addCondensedMilkIceCreamRecipe(output, GrowthcraftMilkItems.ICE_CREAM_GRAPE_WHITE.get(), GrowthcraftCellarItems.GRAPE_WHITE.get(), growthcraft.milk.config.Reference.UnlocalizedName.ICE_CREAM_GRAPE_WHITE);
+        addCondensedMilkIceCreamRecipe(output, GrowthcraftMilkItems.ICE_CREAM_HONEY.get(), Items.HONEYCOMB, growthcraft.milk.config.Reference.UnlocalizedName.ICE_CREAM_HONEY);
+        addCondensedMilkIceCreamRecipe(output, GrowthcraftMilkItems.ICE_CREAM_PUMPKIN.get(), Items.PUMPKIN, growthcraft.milk.config.Reference.UnlocalizedName.ICE_CREAM_PUMPKIN);
+        addCondensedMilkIceCreamRecipe(output, GrowthcraftMilkItems.ICE_CREAM_WATERMELON.get(), Items.MELON_SLICE, growthcraft.milk.config.Reference.UnlocalizedName.ICE_CREAM_WATERMELON);
 
         addYogurtRecipe(output, GrowthcraftMilkItems.YOGURT_APPLE.get(), Items.APPLE, growthcraft.milk.config.Reference.UnlocalizedName.YOGURT_APPLE);
         addYogurtRecipe(output, GrowthcraftMilkItems.YOGURT_CHOCOLATE.get(), Items.COCOA_BEANS, growthcraft.milk.config.Reference.UnlocalizedName.YOGURT_CHOCOLATE);
@@ -543,6 +576,16 @@ public class GrowthcraftRecipeProvider extends RecipeProvider {
                 .group("growthcraft_milk")
                 .unlockedBy("has_milk_bucket", has(GrowthcraftMilkTags.Items.TAG_MILK_BUCKETS))
                 .save(output, ResourceLocation.fromNamespaceAndPath(growthcraft.milk.config.Reference.MODID, name));
+    }
+
+    private static void addCondensedMilkIceCreamRecipe(RecipeOutput output, Item result, Item flavor, String name) {
+        ShapelessRecipeBuilder.shapeless(RecipeCategory.FOOD, result)
+                .requires(GrowthcraftMilkFluids.CONDENSED_MILK.bucket.get())
+                .requires(flavor)
+                .requires(Items.BOWL)
+                .group("growthcraft_milk")
+                .unlockedBy("has_condensed_milk_bucket", has(GrowthcraftMilkFluids.CONDENSED_MILK.bucket.get()))
+                .save(output, ResourceLocation.fromNamespaceAndPath(growthcraft.milk.config.Reference.MODID, name + "_from_condensed_milk"));
     }
 
     private static void addYogurtRecipe(RecipeOutput output, Item result, Item flavor, String name) {

--- a/src/main/resources/data/growthcraft_milk/recipe/brew_kettle_condensed_milk_from_milk.json
+++ b/src/main/resources/data/growthcraft_milk/recipe/brew_kettle_condensed_milk_from_milk.json
@@ -1,0 +1,18 @@
+{
+  "type": "growthcraft_cellar:brew_kettle_recipe",
+  "requires_heat": true,
+  "requires_lid": "false",
+  "processing_time": 600,
+  "input_fluid": {
+    "fluid": "growthcraft_milk:milk_fluid_source",
+    "amount": 1000
+  },
+  "input_item": {
+    "item": "minecraft:sugar",
+    "count": 1
+  },
+  "output_fluid": {
+    "fluid": "growthcraft_milk:condensed_milk_fluid_source",
+    "amount": 1000
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a Brew Kettle source recipe for Condensed Milk from Milk + Sugar.
- Adds Condensed Milk Bucket alternate recipes for all Growthcraft ice cream variants, replacing the normal milk + sugar inputs with sweetened condensed milk.
- Adds Condensed Milk dessert alternates for cake and a higher-output butter cookie recipe.

## Why

Issue #166 identified Condensed Milk as a registered dairy fluid without a source or useful recipe loop. This gives it a clear role as a sweet dairy ingredient while keeping it out of the generic milk bucket tag so it does not accidentally behave like normal milk in yogurt or other dairy flows.

## Validation

- `./gradlew.bat runData`
- `./gradlew.bat build`

## Manual test notes

- Confirm Brew Kettle can make Condensed Milk from Growthcraft Milk + Sugar.
- Confirm JEI shows Condensed Milk alternate ice cream recipes.
- Confirm cake and 24-cookie Condensed Milk recipes appear and craft correctly.

Closes #166