### PR TITLE
Remove startup debug noise and gate debug logging

### DIFF
--- a/src/main/java/growthcraft/apiary/GrowthcraftApiary.java
+++ b/src/main/java/growthcraft/apiary/GrowthcraftApiary.java
@@ -1,6 +1,7 @@
 package growthcraft.apiary;
 
 import com.mojang.logging.LogUtils;
+import growthcraft.apiary.config.GrowthcraftApiaryConfig;
 import growthcraft.apiary.config.Reference;
 import growthcraft.apiary.init.GrowthcraftApiaryBlocks;
 import growthcraft.apiary.init.GrowthcraftApiaryFluids;
@@ -8,7 +9,9 @@ import growthcraft.apiary.init.GrowthcraftApiaryItems;
 import growthcraft.core.init.GrowthcraftCreativeTabs;
 import net.minecraft.world.item.CreativeModeTab;
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.config.ModConfig;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
 import org.slf4j.Logger;
 
@@ -17,13 +20,15 @@ public class GrowthcraftApiary {
     public static final String MODID = Reference.MODID;
     public static final Logger LOGGER = LogUtils.getLogger();
 
-    public GrowthcraftApiary(IEventBus modEventBus) {
+    public GrowthcraftApiary(IEventBus modEventBus, ModContainer modContainer) {
         GrowthcraftApiaryBlocks.BLOCKS.register(modEventBus);
         GrowthcraftApiaryItems.ITEMS.register(modEventBus);
         GrowthcraftApiaryFluids.FLUID_TYPES.register(modEventBus);
         GrowthcraftApiaryFluids.FLUIDS.register(modEventBus);
         GrowthcraftApiaryFluids.BLOCKS.register(modEventBus);
         modEventBus.addListener(this::buildCreativeTab);
+
+        modContainer.registerConfig(ModConfig.Type.COMMON, GrowthcraftApiaryConfig.SPEC);
 
         LOGGER.info("{} module initialized", Reference.NAME);
     }

--- a/src/main/java/growthcraft/apiary/config/GrowthcraftApiaryConfig.java
+++ b/src/main/java/growthcraft/apiary/config/GrowthcraftApiaryConfig.java
@@ -1,0 +1,38 @@
+package growthcraft.apiary.config;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+public final class GrowthcraftApiaryConfig {
+    private static final ModConfigSpec.Builder SERVER_BUILDER = new ModConfigSpec.Builder();
+
+    public static final ModConfigSpec SPEC;
+
+    private static ModConfigSpec.BooleanValue debugEnabled;
+    private static ModConfigSpec.BooleanValue fluidsDebugEnabled;
+
+    static {
+        SERVER_BUILDER.push("debug");
+        debugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional Growthcraft Apiary debug logging.")
+                .define("enabled", false);
+        SERVER_BUILDER.pop();
+
+        SERVER_BUILDER.push("fluids");
+        fluidsDebugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional debug logging for Apiary fluids and waxes.")
+                .define("debugEnabled", false);
+        SERVER_BUILDER.pop();
+
+        SPEC = SERVER_BUILDER.build();
+    }
+
+    public static boolean isDebugEnabled() {
+        return debugEnabled.get();
+    }
+
+    public static boolean isFluidsDebugEnabled() {
+        return fluidsDebugEnabled.get();
+    }
+
+    private GrowthcraftApiaryConfig() {}
+}

--- a/src/main/java/growthcraft/apples/GrowthcraftApples.java
+++ b/src/main/java/growthcraft/apples/GrowthcraftApples.java
@@ -1,6 +1,7 @@
 package growthcraft.apples;
 
 import com.mojang.logging.LogUtils;
+import growthcraft.apples.config.GrowthcraftApplesConfig;
 import growthcraft.apples.config.Reference;
 import growthcraft.apples.init.GrowthcraftApplesBlocks;
 import growthcraft.apples.init.GrowthcraftApplesFluids;
@@ -11,7 +12,9 @@ import net.minecraft.world.level.block.RotatedPillarBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.config.ModConfig;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.neoforge.common.ItemAbilities;
 import net.neoforged.neoforge.common.NeoForge;
@@ -24,7 +27,7 @@ public class GrowthcraftApples {
     public static final String MODID = Reference.MODID;
     public static final Logger LOGGER = LogUtils.getLogger();
 
-    public GrowthcraftApples(IEventBus modEventBus) {
+    public GrowthcraftApples(IEventBus modEventBus, ModContainer modContainer) {
         modEventBus.addListener(this::commonSetup);
         GrowthcraftApplesBlocks.BLOCKS.register(modEventBus);
         GrowthcraftApplesItems.ITEMS.register(modEventBus);
@@ -33,6 +36,8 @@ public class GrowthcraftApples {
         GrowthcraftApplesFluids.BLOCKS.register(modEventBus);
         modEventBus.addListener(this::buildCreativeTab);
         NeoForge.EVENT_BUS.register(this);
+
+        modContainer.registerConfig(ModConfig.Type.COMMON, GrowthcraftApplesConfig.SPEC);
 
         LOGGER.info("{} module initialized", Reference.NAME);
     }

--- a/src/main/java/growthcraft/apples/config/GrowthcraftApplesConfig.java
+++ b/src/main/java/growthcraft/apples/config/GrowthcraftApplesConfig.java
@@ -1,0 +1,60 @@
+package growthcraft.apples.config;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+public final class GrowthcraftApplesConfig {
+    private static final ModConfigSpec.Builder SERVER_BUILDER = new ModConfigSpec.Builder();
+
+    public static final ModConfigSpec SPEC;
+
+    private static ModConfigSpec.BooleanValue debugEnabled;
+    private static ModConfigSpec.BooleanValue blocksDebugEnabled;
+    private static ModConfigSpec.BooleanValue cropsDebugEnabled;
+    private static ModConfigSpec.BooleanValue fluidsDebugEnabled;
+
+    static {
+        SERVER_BUILDER.push("debug");
+        debugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional Growthcraft Apples debug logging.")
+                .define("enabled", false);
+        SERVER_BUILDER.pop();
+
+        SERVER_BUILDER.push("blocks");
+        blocksDebugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional debug logging for Apple wood and block interactions.")
+                .define("debugEnabled", false);
+        SERVER_BUILDER.pop();
+
+        SERVER_BUILDER.push("crops");
+        cropsDebugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional debug logging for Apple tree growth and fruit blocks.")
+                .define("debugEnabled", false);
+        SERVER_BUILDER.pop();
+
+        SERVER_BUILDER.push("fluids");
+        fluidsDebugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional debug logging for Apples fluids.")
+                .define("debugEnabled", false);
+        SERVER_BUILDER.pop();
+
+        SPEC = SERVER_BUILDER.build();
+    }
+
+    public static boolean isDebugEnabled() {
+        return debugEnabled.get();
+    }
+
+    public static boolean isBlocksDebugEnabled() {
+        return blocksDebugEnabled.get();
+    }
+
+    public static boolean isCropsDebugEnabled() {
+        return cropsDebugEnabled.get();
+    }
+
+    public static boolean isFluidsDebugEnabled() {
+        return fluidsDebugEnabled.get();
+    }
+
+    private GrowthcraftApplesConfig() {}
+}

--- a/src/main/java/growthcraft/bamboo/GrowthcraftBamboo.java
+++ b/src/main/java/growthcraft/bamboo/GrowthcraftBamboo.java
@@ -1,13 +1,16 @@
 package growthcraft.bamboo;
 
 import com.mojang.logging.LogUtils;
+import growthcraft.bamboo.config.GrowthcraftBambooConfig;
 import growthcraft.bamboo.config.Reference;
 import growthcraft.bamboo.init.GrowthcraftBambooBlocks;
 import growthcraft.bamboo.init.GrowthcraftBambooItems;
 import growthcraft.core.init.GrowthcraftCreativeTabs;
 import net.minecraft.world.item.CreativeModeTab;
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.config.ModConfig;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
 import org.slf4j.Logger;
 
@@ -16,10 +19,12 @@ public class GrowthcraftBamboo {
     public static final String MODID = Reference.MODID;
     public static final Logger LOGGER = LogUtils.getLogger();
 
-    public GrowthcraftBamboo(IEventBus modEventBus) {
+    public GrowthcraftBamboo(IEventBus modEventBus, ModContainer modContainer) {
         GrowthcraftBambooBlocks.BLOCKS.register(modEventBus);
         GrowthcraftBambooItems.ITEMS.register(modEventBus);
         modEventBus.addListener(this::buildCreativeTab);
+
+        modContainer.registerConfig(ModConfig.Type.COMMON, GrowthcraftBambooConfig.SPEC);
 
         LOGGER.info("{} module initialized", Reference.NAME);
     }

--- a/src/main/java/growthcraft/bamboo/config/GrowthcraftBambooConfig.java
+++ b/src/main/java/growthcraft/bamboo/config/GrowthcraftBambooConfig.java
@@ -1,0 +1,38 @@
+package growthcraft.bamboo.config;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+public final class GrowthcraftBambooConfig {
+    private static final ModConfigSpec.Builder SERVER_BUILDER = new ModConfigSpec.Builder();
+
+    public static final ModConfigSpec SPEC;
+
+    private static ModConfigSpec.BooleanValue debugEnabled;
+    private static ModConfigSpec.BooleanValue blocksDebugEnabled;
+
+    static {
+        SERVER_BUILDER.push("debug");
+        debugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional Growthcraft Bamboo debug logging.")
+                .define("enabled", false);
+        SERVER_BUILDER.pop();
+
+        SERVER_BUILDER.push("blocks");
+        blocksDebugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional debug logging for Bamboo blocks.")
+                .define("debugEnabled", false);
+        SERVER_BUILDER.pop();
+
+        SPEC = SERVER_BUILDER.build();
+    }
+
+    public static boolean isDebugEnabled() {
+        return debugEnabled.get();
+    }
+
+    public static boolean isBlocksDebugEnabled() {
+        return blocksDebugEnabled.get();
+    }
+
+    private GrowthcraftBambooConfig() {}
+}

--- a/src/main/java/growthcraft/cellar/GrowthcraftCellar.java
+++ b/src/main/java/growthcraft/cellar/GrowthcraftCellar.java
@@ -7,14 +7,10 @@ import growthcraft.cellar.init.*;
 import growthcraft.core.init.GrowthcraftCreativeTabs;
 import net.minecraft.world.item.CreativeModeTab;
 import net.neoforged.bus.api.IEventBus;
-import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.config.ModConfig;
-import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
-import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
-import net.neoforged.neoforge.event.server.ServerStartingEvent;
 import org.slf4j.Logger;
 
 // The value here should match an entry in the META-INF/neoforge.mods.toml file
@@ -24,9 +20,6 @@ public class GrowthcraftCellar {
     public static final Logger LOGGER = LogUtils.getLogger();
 
     public GrowthcraftCellar(IEventBus modEventBus, ModContainer modContainer) {
-        // Register the commonSetup
-        modEventBus.addListener(this::commonSetup);
-
         // Register Deferred Registers
         GrowthcraftCellarItems.ITEMS.register(modEventBus);
         GrowthcraftCellarBlocks.BLOCKS.register(modEventBus);
@@ -44,13 +37,7 @@ public class GrowthcraftCellar {
         // Add creative tab contributions
         modEventBus.addListener(this::buildCreativeTab);
 
-        NeoForge.EVENT_BUS.register(this);
-
         modContainer.registerConfig(ModConfig.Type.COMMON, GrowthcraftCellarConfig.SPEC);
-    }
-
-    private void commonSetup(FMLCommonSetupEvent event) {
-        LOGGER.info("HELLO FROM COMMON SETUP");
     }
 
     private void buildCreativeTab(BuildCreativeModeTabContentsEvent event) {
@@ -110,11 +97,5 @@ public class GrowthcraftCellar {
                 event.accept(container.bucket.get());
             }
         }
-    }
-
-    // You can use SubscribeEvent and let the Event Bus discover methods to call
-    @SubscribeEvent
-    public void onServerStarting(ServerStartingEvent event) {
-        LOGGER.info("HELLO from server starting");
     }
 }

--- a/src/main/java/growthcraft/cellar/GrowthcraftCellarClient.java
+++ b/src/main/java/growthcraft/cellar/GrowthcraftCellarClient.java
@@ -9,7 +9,6 @@ import growthcraft.cellar.client.screen.FruitPressScreen;
 import growthcraft.cellar.client.screen.RoasterScreen;
 import growthcraft.core.Growthcraft;
 import growthcraft.lib.fluid.FluidRegistryContainer;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.RenderType;
@@ -37,10 +36,6 @@ public class GrowthcraftCellarClient {
 
     @SubscribeEvent
     static void onClientSetup(FMLClientSetupEvent event) {
-        // Some client setup code
-        Growthcraft.LOGGER.info("HELLO FROM CLIENT SETUP");
-        Growthcraft.LOGGER.info("MINECRAFT NAME >> {}", Minecraft.getInstance().getUser().getName());
-
         // Ensure all Growthcraft Cellar fluids render as translucent like water
         event.enqueueWork(() -> {
             RenderType translucent = RenderType.translucent();

--- a/src/main/java/growthcraft/cellar/block/CultureJarBlock.java
+++ b/src/main/java/growthcraft/cellar/block/CultureJarBlock.java
@@ -3,6 +3,7 @@ package growthcraft.cellar.block;
 import com.mojang.serialization.MapCodec;
 import growthcraft.cellar.GrowthcraftCellar;
 import growthcraft.cellar.block.entity.CultureJarBlockEntity;
+import growthcraft.cellar.config.GrowthcraftCellarConfig;
 import growthcraft.milk.item.GrowthcraftMilkBucketItem;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -42,6 +43,12 @@ import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 
 public class CultureJarBlock extends HorizontalDirectionalBlock implements EntityBlock, net.minecraft.world.level.block.BucketPickup {
     public static final BooleanProperty LIT = BlockStateProperties.LIT;
+
+    private static void debug(String message, Object... args) {
+        if (GrowthcraftCellarConfig.isCultureJarDebugEnabled()) {
+            GrowthcraftCellar.LOGGER.debug(message, args);
+        }
+    }
     public static final MapCodec<CultureJarBlock> CODEC = simpleCodec(CultureJarBlock::new);
 
     private static final TagKey<Block> HEAT_SOURCE_TAG = TagKey.create(Registries.BLOCK, ResourceLocation.fromNamespaceAndPath(Reference.MODID, Reference.UnlocalizedName.Tag.HEATSOURCES));
@@ -147,17 +154,17 @@ public class CultureJarBlock extends HorizontalDirectionalBlock implements Entit
         boolean mainIsBucket = main.getItem() instanceof BucketItem || main.getItem() instanceof growthcraft.milk.item.MilkingBucketItem || main.is(Items.MILK_BUCKET);
         boolean offIsBucket = off.getItem() instanceof BucketItem || off.getItem() instanceof growthcraft.milk.item.MilkingBucketItem || off.is(Items.MILK_BUCKET);
         if (mainIsBucket || offIsBucket) {
-            GrowthcraftCellar.LOGGER.debug("[CultureJar] useWithoutItem: Player={} MainHand={} OffHand={} mainIsBucket={} offIsBucket={} -> passing to useItemOn", player.getGameProfile().getName(), main.getItem(), off.getItem(), mainIsBucket, offIsBucket);
+            debug("[CultureJar] useWithoutItem: Player={} MainHand={} OffHand={} mainIsBucket={} offIsBucket={} -> passing to useItemOn", player.getGameProfile().getName(), main.getItem(), off.getItem(), mainIsBucket, offIsBucket);
             return InteractionResult.PASS;
         }
 
         if (!level.isClientSide) {
             net.minecraft.world.level.block.entity.BlockEntity be = level.getBlockEntity(pos);
             if (be instanceof net.minecraft.world.MenuProvider provider) {
-                GrowthcraftCellar.LOGGER.debug("[CultureJar] Opening menu at {} for player {}", pos, player.getGameProfile().getName());
+                debug("[CultureJar] Opening menu at {} for player {}", pos, player.getGameProfile().getName());
                 player.openMenu(provider);
             } else {
-                GrowthcraftCellar.LOGGER.debug("[CultureJar] No MenuProvider at {} when player {} used without item", pos, player.getGameProfile().getName());
+                debug("[CultureJar] No MenuProvider at {} when player {} used without item", pos, player.getGameProfile().getName());
             }
             return InteractionResult.CONSUME;
         }
@@ -177,7 +184,7 @@ public class CultureJarBlock extends HorizontalDirectionalBlock implements Entit
 
         BlockEntity be = level.getBlockEntity(pos);
         if (!(be instanceof CultureJarBlockEntity jar)) {
-            GrowthcraftCellar.LOGGER.debug("[CultureJar] useItemOn: No CultureJarBlockEntity at {} (got {}), passing.", pos, be);
+            debug("[CultureJar] useItemOn: No CultureJarBlockEntity at {} (got {}), passing.", pos, be);
             return ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
         }
 
@@ -188,29 +195,29 @@ public class CultureJarBlock extends HorizontalDirectionalBlock implements Entit
             var before = jar.getTank().getFluid().copy();
             String beforeName = before.isEmpty() ? "<empty>" : before.getHoverName().getString();
             int capacity = jar.getTank().getTankCapacity(0);
-            GrowthcraftCellar.LOGGER.debug("[CultureJar] useItemOn(Server): Player={} Hand={} HeldItem={} (class={}) Facing={} TankBefore={}mB/{} {}",
+            debug("[CultureJar] useItemOn(Server): Player={} Hand={} HeldItem={} (class={}) Facing={} TankBefore={}mB/{} {}",
                     player.getGameProfile().getName(), hand, heldStack.getItem(), heldStack.getItem().getClass().getName(), hit.getDirection(), before.getAmount(), capacity, beforeName);
 
             // 1) If holding a vanilla Milk Bucket, deposit Growthcraft milk into the jar and return an empty vanilla bucket.
             if (heldStack.is(Items.MILK_BUCKET)) {
                 net.neoforged.neoforge.fluids.FluidStack toInsert = new net.neoforged.neoforge.fluids.FluidStack(
                         growthcraft.milk.init.GrowthcraftMilkFluids.MILK.source.get(), 1000);
-                GrowthcraftCellar.LOGGER.debug("[CultureJar] Vanilla milk bucket deposit: request={}mB spaceAvailable={}mB", 1000, capacity - jar.getTank().getFluidAmount());
+                debug("[CultureJar] Vanilla milk bucket deposit: request={}mB spaceAvailable={}mB", 1000, capacity - jar.getTank().getFluidAmount());
                 int filled = jar.getTank().fill(toInsert, IFluidHandler.FluidAction.EXECUTE);
-                GrowthcraftCellar.LOGGER.debug("[CultureJar] Vanilla milk bucket deposit result: filled={} newTank={}mB", filled, jar.getTank().getFluidAmount());
+                debug("[CultureJar] Vanilla milk bucket deposit result: filled={} newTank={}mB", filled, jar.getTank().getFluidAmount());
                 if (filled == 1000) {
                     if (!player.getAbilities().instabuild) {
                         ItemStack remainder = new ItemStack(Items.BUCKET);
                         player.setItemInHand(hand, remainder);
-                        GrowthcraftCellar.LOGGER.debug("[CultureJar] Consumed vanilla milk bucket, returned {}", remainder.getItem());
+                        debug("[CultureJar] Consumed vanilla milk bucket, returned {}", remainder.getItem());
                     } else {
-                        GrowthcraftCellar.LOGGER.debug("[CultureJar] Player in creative, not consuming bucket");
+                        debug("[CultureJar] Player in creative, not consuming bucket");
                     }
                     be.setChanged();
                     level.sendBlockUpdated(pos, state, state, 3);
                     return ItemInteractionResult.SUCCESS;
                 } else {
-                    GrowthcraftCellar.LOGGER.debug("[CultureJar] Vanilla milk bucket deposit could not insert full 1000mB (inserted={}), will continue", filled);
+                    debug("[CultureJar] Vanilla milk bucket deposit could not insert full 1000mB (inserted={}), will continue", filled);
                 }
             }
 
@@ -218,22 +225,22 @@ public class CultureJarBlock extends HorizontalDirectionalBlock implements Entit
             if (heldStack.getItem() instanceof GrowthcraftMilkBucketItem milkBucket) {
                 net.neoforged.neoforge.fluids.FluidStack toInsert = new net.neoforged.neoforge.fluids.FluidStack(
                         growthcraft.milk.init.GrowthcraftMilkFluids.MILK.source.get(), 1000);
-                GrowthcraftCellar.LOGGER.debug("[CultureJar] Attempting priority milk deposit: request={}mB spaceAvailable={}mB", 1000, capacity - jar.getTank().getFluidAmount());
+                debug("[CultureJar] Attempting priority milk deposit: request={}mB spaceAvailable={}mB", 1000, capacity - jar.getTank().getFluidAmount());
                 int filled = jar.getTank().fill(toInsert, IFluidHandler.FluidAction.EXECUTE);
-                GrowthcraftCellar.LOGGER.debug("[CultureJar] Priority milk deposit result: filled={} newTank={}mB", filled, jar.getTank().getFluidAmount());
+                debug("[CultureJar] Priority milk deposit result: filled={} newTank={}mB", filled, jar.getTank().getFluidAmount());
                 if (filled == 1000) {
                     if (!player.getAbilities().instabuild) {
                         ItemStack remainder = milkBucket.getCraftingRemainingItem(heldStack);
                         player.setItemInHand(hand, remainder.copy());
-                        GrowthcraftCellar.LOGGER.debug("[CultureJar] Consumed filled Growthcraft milk bucket, returned {}", remainder.getItem());
+                        debug("[CultureJar] Consumed filled Growthcraft milk bucket, returned {}", remainder.getItem());
                     } else {
-                        GrowthcraftCellar.LOGGER.debug("[CultureJar] Player in creative, not consuming bucket");
+                        debug("[CultureJar] Player in creative, not consuming bucket");
                     }
                     be.setChanged();
                     level.sendBlockUpdated(pos, state, state, 3);
                     return ItemInteractionResult.SUCCESS;
                 } else {
-                    GrowthcraftCellar.LOGGER.debug("[CultureJar] Priority milk deposit could not insert full 1000mB (inserted={}), will continue", filled);
+                    debug("[CultureJar] Priority milk deposit could not insert full 1000mB (inserted={}), will continue", filled);
                 }
             }
 
@@ -241,10 +248,10 @@ public class CultureJarBlock extends HorizontalDirectionalBlock implements Entit
             if (isMilkingBucket) {
                 net.neoforged.neoforge.fluids.FluidStack inTank = jar.getTank().getFluid();
                 boolean correctFluid = !inTank.isEmpty() && inTank.getFluid() == growthcraft.milk.init.GrowthcraftMilkFluids.MILK.source.get();
-                GrowthcraftCellar.LOGGER.debug("[CultureJar] Milking bucket fill check: hasMilk={} amount={}mB", correctFluid, inTank.getAmount());
+                debug("[CultureJar] Milking bucket fill check: hasMilk={} amount={}mB", correctFluid, inTank.getAmount());
                 if (correctFluid && inTank.getAmount() >= 1000) {
                     net.neoforged.neoforge.fluids.FluidStack drained = jar.getTank().drain(1000, IFluidHandler.FluidAction.EXECUTE);
-                    GrowthcraftCellar.LOGGER.debug("[CultureJar] Drained from jar for milking bucket: {}mB", drained.getAmount());
+                    debug("[CultureJar] Drained from jar for milking bucket: {}mB", drained.getAmount());
                     if (drained.getAmount() == 1000) {
                         ItemStack filledStack = new ItemStack(growthcraft.milk.init.GrowthcraftMilkItems.MILK_BUCKET_IRON.get());
                         if (!player.getAbilities().instabuild) {
@@ -252,24 +259,24 @@ public class CultureJarBlock extends HorizontalDirectionalBlock implements Entit
                         }
                         be.setChanged();
                         level.sendBlockUpdated(pos, state, state, 3);
-                        GrowthcraftCellar.LOGGER.debug("[CultureJar] Filled milking bucket from jar. Now {}mB left", jar.getTank().getFluidAmount());
+                        debug("[CultureJar] Filled milking bucket from jar. Now {}mB left", jar.getTank().getFluidAmount());
                         return ItemInteractionResult.SUCCESS;
                     } else {
-                        GrowthcraftCellar.LOGGER.debug("[CultureJar] Unexpected: drained {}mB for milking bucket (expected 1000)", drained.getAmount());
+                        debug("[CultureJar] Unexpected: drained {}mB for milking bucket (expected 1000)", drained.getAmount());
                     }
                 } else {
-                    GrowthcraftCellar.LOGGER.debug("[CultureJar] Not enough milk to fill milking bucket or wrong fluid");
+                    debug("[CultureJar] Not enough milk to fill milking bucket or wrong fluid");
                 }
             }
 
             // 4) Fallback to generic fluid interaction (vanilla buckets and others)
-            GrowthcraftCellar.LOGGER.debug("[CultureJar] Fallback FluidUtil.interactWithFluidHandler: player={} hand={} face={} item={} (class={})",
+            debug("[CultureJar] Fallback FluidUtil.interactWithFluidHandler: player={} hand={} face={} item={} (class={})",
                     player.getGameProfile().getName(), hand, hit.getDirection(), heldStack.getItem(), heldStack.getItem().getClass().getName());
             boolean acted = FluidUtil.interactWithFluidHandler(player, hand, level, pos, hit.getDirection());
 
             var after = jar.getTank().getFluid();
             String afterName = after.isEmpty() ? "<empty>" : after.getHoverName().getString();
-            GrowthcraftCellar.LOGGER.debug("[CultureJar] useItemOn(Server): acted={} AfterTank={}mB {}", acted, jar.getTank().getFluidAmount(), afterName);
+            debug("[CultureJar] useItemOn(Server): acted={} AfterTank={}mB {}", acted, jar.getTank().getFluidAmount(), afterName);
             if (acted) {
                 be.setChanged();
                 // notify clients so GUIs/models can refresh
@@ -277,13 +284,13 @@ public class CultureJarBlock extends HorizontalDirectionalBlock implements Entit
                 return ItemInteractionResult.SUCCESS;
             }
             if (!heldStack.is(Items.BUCKET) && !isMilkingBucket) {
-                GrowthcraftCellar.LOGGER.debug("[CultureJar] Filled bucket interaction targeted jar but did not act; consuming to prevent world placement");
+                debug("[CultureJar] Filled bucket interaction targeted jar but did not act; consuming to prevent world placement");
                 return ItemInteractionResult.SUCCESS;
             }
-            GrowthcraftCellar.LOGGER.debug("[CultureJar] FluidUtil fallback did not act; passing to default block interaction");
+            debug("[CultureJar] FluidUtil fallback did not act; passing to default block interaction");
             return ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
         }
-        GrowthcraftCellar.LOGGER.debug("[CultureJar] useItemOn(Client): consuming bucket interaction for jar target. Player={} Hand={} Item={} (class={})", player.getGameProfile().getName(), hand, heldStack.getItem(), heldStack.getItem().getClass().getName());
+        debug("[CultureJar] useItemOn(Client): consuming bucket interaction for jar target. Player={} Hand={} Item={} (class={})", player.getGameProfile().getName(), hand, heldStack.getItem(), heldStack.getItem().getClass().getName());
         return ItemInteractionResult.SUCCESS;
     }
 
@@ -306,17 +313,17 @@ public class CultureJarBlock extends HorizontalDirectionalBlock implements Entit
     public net.minecraft.world.item.ItemStack pickupBlock(net.minecraft.world.entity.player.Player player, net.minecraft.world.level.LevelAccessor level, BlockPos pos, BlockState state) {
         BlockEntity be = level.getBlockEntity(pos);
         if (!(be instanceof CultureJarBlockEntity jar)) {
-            GrowthcraftCellar.LOGGER.debug("[CultureJar] BucketPickup: No CultureJarBlockEntity at {} (got {}), returning EMPTY", pos, be);
+            debug("[CultureJar] BucketPickup: No CultureJarBlockEntity at {} (got {}), returning EMPTY", pos, be);
             return net.minecraft.world.item.ItemStack.EMPTY;
         }
         var tank = jar.getTank();
         net.neoforged.neoforge.fluids.FluidStack inTank = tank.getFluid();
         boolean isMilk = !inTank.isEmpty() && inTank.getFluid() == growthcraft.milk.init.GrowthcraftMilkFluids.MILK.source.get();
         int amount = inTank.getAmount();
-        GrowthcraftCellar.LOGGER.debug("[CultureJar] BucketPickup: isMilk={} amount={}mB", isMilk, amount);
+        debug("[CultureJar] BucketPickup: isMilk={} amount={}mB", isMilk, amount);
         if (isMilk && amount >= 1000) {
             net.neoforged.neoforge.fluids.FluidStack drained = tank.drain(1000, IFluidHandler.FluidAction.EXECUTE);
-            GrowthcraftCellar.LOGGER.debug("[CultureJar] BucketPickup: drained {}mB", drained.getAmount());
+            debug("[CultureJar] BucketPickup: drained {}mB", drained.getAmount());
             if (drained.getAmount() == 1000) {
                 if (level instanceof Level lvl) {
                     be.setChanged();

--- a/src/main/java/growthcraft/cellar/block/entity/CultureJarBlockEntity.java
+++ b/src/main/java/growthcraft/cellar/block/entity/CultureJarBlockEntity.java
@@ -2,6 +2,7 @@ package growthcraft.cellar.block.entity;
 
 import growthcraft.cellar.GrowthcraftCellar;
 import growthcraft.cellar.block.CultureJarBlock;
+import growthcraft.cellar.config.GrowthcraftCellarConfig;
 import growthcraft.cellar.init.GrowthcraftCellarBlockEntities;
 import growthcraft.cellar.init.GrowthcraftCellarRecipes;
 import growthcraft.cellar.recipe.CultureJarRecipe;
@@ -33,6 +34,12 @@ public class CultureJarBlockEntity extends BlockEntity implements WorldlyContain
     public static final int SLOT_COUNT = 2;
     public static final int TANK_CAPACITY = 1000; // 1 bucket
 
+    private static void debug(String message, Object... args) {
+        if (GrowthcraftCellarConfig.isCultureJarDebugEnabled()) {
+            GrowthcraftCellar.LOGGER.debug(message, args);
+        }
+    }
+
     private final NonNullList<ItemStack> items = NonNullList.withSize(SLOT_COUNT, ItemStack.EMPTY);
     private final int[] TOP_SLOTS = new int[] { SLOT_INPUT };
     private final int[] BOTTOM_SLOTS = new int[] { SLOT_OUTPUT };
@@ -44,7 +51,7 @@ public class CultureJarBlockEntity extends BlockEntity implements WorldlyContain
             setChanged();
             var fluid = getFluid();
             String name = fluid.isEmpty() ? "<empty>" : fluid.getHoverName().getString();
-            GrowthcraftCellar.LOGGER.debug("[CultureJarBE] Tank changed at {}: {} mB {}", worldPosition, fluid.getAmount(), name);
+            debug("[CultureJarBE] Tank changed at {}: {} mB {}", worldPosition, fluid.getAmount(), name);
             // Ensure clients are notified so GUIs and rendering update
             if (level != null && !level.isClientSide) {
                 BlockState state = getBlockState();
@@ -53,7 +60,7 @@ public class CultureJarBlockEntity extends BlockEntity implements WorldlyContain
                 if (level instanceof net.minecraft.server.level.ServerLevel serverLevel) {
                     serverLevel.getChunkSource().blockChanged(worldPosition);
                 }
-                GrowthcraftCellar.LOGGER.debug("[CultureJarBE] Sent block update for GUI sync at {}", worldPosition);
+                debug("[CultureJarBE] Sent block update for GUI sync at {}", worldPosition);
             }
         }
     };
@@ -179,7 +186,7 @@ public class CultureJarBlockEntity extends BlockEntity implements WorldlyContain
         // Processing
         tag.putInt("ProcessTime", this.processTime);
         tag.putInt("ProcessTimeTotal", this.processTimeTotal);
-        GrowthcraftCellar.LOGGER.debug("[CultureJarBE] saveAdditional at {}: items={} tank={}mB time={}/{}", worldPosition, this.items.stream().filter(s -> !s.isEmpty()).count(), this.tank.getFluidAmount(), this.processTime, this.processTimeTotal);
+        debug("[CultureJarBE] saveAdditional at {}: items={} tank={}mB time={}/{}", worldPosition, this.items.stream().filter(s -> !s.isEmpty()).count(), this.tank.getFluidAmount(), this.processTime, this.processTimeTotal);
     }
 
     @Override
@@ -194,7 +201,7 @@ public class CultureJarBlockEntity extends BlockEntity implements WorldlyContain
         // Processing
         this.processTime = tag.getInt("ProcessTime");
         this.processTimeTotal = tag.getInt("ProcessTimeTotal");
-        GrowthcraftCellar.LOGGER.debug("[CultureJarBE] loadAdditional at {}: items={} tank={}mB time={}/{}", worldPosition, this.items.stream().filter(s -> !s.isEmpty()).count(), this.tank.getFluidAmount(), this.processTime, this.processTimeTotal);
+        debug("[CultureJarBE] loadAdditional at {}: items={} tank={}mB time={}/{}", worldPosition, this.items.stream().filter(s -> !s.isEmpty()).count(), this.tank.getFluidAmount(), this.processTime, this.processTimeTotal);
     }
 
     // --- Client sync for renderer/GUI ---

--- a/src/main/java/growthcraft/cellar/config/GrowthcraftCellarConfig.java
+++ b/src/main/java/growthcraft/cellar/config/GrowthcraftCellarConfig.java
@@ -10,6 +10,14 @@ public class GrowthcraftCellarConfig {
     // Do we allow rice and corn as adjunct grains in brewing recipes
     private static ModConfigSpec.BooleanValue secondaryAdjunctGrainsAllowed;
     private static ModConfigSpec.IntValue grapeVineMaxHeight;
+    private static ModConfigSpec.BooleanValue debugEnabled;
+    private static ModConfigSpec.BooleanValue brewKettleDebugEnabled;
+    private static ModConfigSpec.BooleanValue cultureJarDebugEnabled;
+    private static ModConfigSpec.BooleanValue fermentationBarrelDebugEnabled;
+    private static ModConfigSpec.BooleanValue fruitPressDebugEnabled;
+    private static ModConfigSpec.BooleanValue roasterDebugEnabled;
+    private static ModConfigSpec.BooleanValue cropsDebugEnabled;
+    private static ModConfigSpec.BooleanValue capabilitiesDebugEnabled;
 
     static {
         SERVER_BUILDER.push("brewing");
@@ -22,6 +30,51 @@ public class GrowthcraftCellarConfig {
         grapeVineMaxHeight = SERVER_BUILDER
                 .comment("Maximum height that grape vines can climb before producing horizontal leaves.")
                 .defineInRange("grape_vine_max_height", 8, 1, 32);
+        cropsDebugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional debug logging for Cellar crops.")
+                .define("debugEnabled", false);
+        SERVER_BUILDER.pop();
+
+        SERVER_BUILDER.push("debug");
+        debugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional Growthcraft Cellar debug logging.")
+                .define("enabled", false);
+        SERVER_BUILDER.pop();
+
+        SERVER_BUILDER.push("brew_kettle");
+        brewKettleDebugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional logging to debug the Brew Kettle.")
+                .define("debugEnabled", false);
+        SERVER_BUILDER.pop();
+
+        SERVER_BUILDER.push("culture_jar");
+        cultureJarDebugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional logging to debug Culture Jar interactions and tank sync.")
+                .define("debugEnabled", false);
+        SERVER_BUILDER.pop();
+
+        SERVER_BUILDER.push("fermentation_barrel");
+        fermentationBarrelDebugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional logging to debug the Fermentation Barrel.")
+                .define("debugEnabled", false);
+        SERVER_BUILDER.pop();
+
+        SERVER_BUILDER.push("fruit_press");
+        fruitPressDebugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional logging to debug the Fruit Press.")
+                .define("debugEnabled", false);
+        SERVER_BUILDER.pop();
+
+        SERVER_BUILDER.push("roaster");
+        roasterDebugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional logging to debug the Roaster.")
+                .define("debugEnabled", false);
+        SERVER_BUILDER.pop();
+
+        SERVER_BUILDER.push("capabilities");
+        capabilitiesDebugEnabled = SERVER_BUILDER
+                .comment("Set to true to log Cellar capability registration details.")
+                .define("debugEnabled", false);
         SERVER_BUILDER.pop();
 
         SPEC = SERVER_BUILDER.build();
@@ -34,6 +87,38 @@ public class GrowthcraftCellarConfig {
 
     public static int getGrapeVineMaxHeight() {
         return grapeVineMaxHeight.get();
+    }
+
+    public static boolean isDebugEnabled() {
+        return debugEnabled.get();
+    }
+
+    public static boolean isBrewKettleDebugEnabled() {
+        return brewKettleDebugEnabled.get();
+    }
+
+    public static boolean isCultureJarDebugEnabled() {
+        return cultureJarDebugEnabled.get();
+    }
+
+    public static boolean isFermentationBarrelDebugEnabled() {
+        return fermentationBarrelDebugEnabled.get();
+    }
+
+    public static boolean isFruitPressDebugEnabled() {
+        return fruitPressDebugEnabled.get();
+    }
+
+    public static boolean isRoasterDebugEnabled() {
+        return roasterDebugEnabled.get();
+    }
+
+    public static boolean isCropsDebugEnabled() {
+        return cropsDebugEnabled.get();
+    }
+
+    public static boolean isCapabilitiesDebugEnabled() {
+        return capabilitiesDebugEnabled.get();
     }
 
     private GrowthcraftCellarConfig() {}

--- a/src/main/java/growthcraft/cellar/init/GrowthcraftCellarCapabilities.java
+++ b/src/main/java/growthcraft/cellar/init/GrowthcraftCellarCapabilities.java
@@ -5,6 +5,7 @@ import growthcraft.cellar.block.entity.BrewKettleBlockEntity;
 import growthcraft.cellar.block.entity.CultureJarBlockEntity;
 import growthcraft.cellar.block.entity.FermentationBarrelBlockEntity;
 import growthcraft.cellar.block.entity.FruitPressBlockEntity;
+import growthcraft.cellar.config.GrowthcraftCellarConfig;
 import net.minecraft.core.Direction;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
@@ -17,20 +18,26 @@ public final class GrowthcraftCellarCapabilities {
 
     public static void registerCapabilities(RegisterCapabilitiesEvent event) {
         // Expose the Culture Jar's internal tank as a fluid handler capability
-        GrowthcraftCellar.LOGGER.debug("[Capabilities] Registering FluidHandler for Culture Jar BE");
+        debug("[Capabilities] Registering FluidHandler for Culture Jar BE");
         event.registerBlockEntity(Capabilities.FluidHandler.BLOCK, GrowthcraftCellarBlockEntities.CULTURE_JAR.get(),
                 (CultureJarBlockEntity be, net.minecraft.core.Direction side) -> be.getTank());
 
-        GrowthcraftCellar.LOGGER.debug("[Capabilities] Registering FluidHandlers for Brew Kettle BE");
+        debug("[Capabilities] Registering FluidHandlers for Brew Kettle BE");
         event.registerBlockEntity(Capabilities.FluidHandler.BLOCK, GrowthcraftCellarBlockEntities.BREW_KETTLE.get(),
                 (BrewKettleBlockEntity be, Direction side) -> side == Direction.UP ? be.getInputTank() : be.getOutputTank());
 
-        GrowthcraftCellar.LOGGER.debug("[Capabilities] Registering FluidHandler for Fermentation Barrel BE");
+        debug("[Capabilities] Registering FluidHandler for Fermentation Barrel BE");
         event.registerBlockEntity(Capabilities.FluidHandler.BLOCK, GrowthcraftCellarBlockEntities.FERMENTATION_BARREL.get(),
                 (FermentationBarrelBlockEntity be, Direction side) -> be.getTank());
 
-        GrowthcraftCellar.LOGGER.debug("[Capabilities] Registering FluidHandler for Fruit Press BE");
+        debug("[Capabilities] Registering FluidHandler for Fruit Press BE");
         event.registerBlockEntity(Capabilities.FluidHandler.BLOCK, GrowthcraftCellarBlockEntities.FRUIT_PRESS.get(),
                 (FruitPressBlockEntity be, Direction side) -> be.getTank());
+    }
+
+    private static void debug(String message, Object... args) {
+        if (GrowthcraftCellarConfig.isCapabilitiesDebugEnabled()) {
+            GrowthcraftCellar.LOGGER.debug(message, args);
+        }
     }
 }

--- a/src/main/java/growthcraft/core/Growthcraft.java
+++ b/src/main/java/growthcraft/core/Growthcraft.java
@@ -14,13 +14,10 @@ import org.slf4j.Logger;
 import com.mojang.logging.LogUtils;
 
 import net.neoforged.bus.api.IEventBus;
-import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.config.ModConfig;
 import net.neoforged.fml.ModContainer;
-import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.neoforge.common.NeoForge;
-import net.neoforged.neoforge.event.server.ServerStartingEvent;
 
 //
 // AIDER_SANITY_TEST_12345
@@ -32,9 +29,6 @@ public class Growthcraft {
     public static final Logger LOGGER = LogUtils.getLogger();
 
     public Growthcraft(IEventBus modEventBus, ModContainer modContainer) {
-        // Register the commonSetup method for modloading
-        modEventBus.addListener(this::commonSetup);
-
         // Register Deferred Registers
         GrowthcraftItems.ITEMS.register(modEventBus);
         GrowthcraftBlocks.BLOCKS.register(modEventBus);
@@ -42,20 +36,9 @@ public class Growthcraft {
         GrowthcraftConditions.CONDITION_CODECS.register(modEventBus);
         GrowthcraftParticles.PARTICLE_TYPES.register(modEventBus);
 
-        NeoForge.EVENT_BUS.register(this);
         NeoForge.EVENT_BUS.addListener(RopeShearHandler::onRightClickBlock);
         NeoForge.EVENT_BUS.addListener(ShopSignTransformHandler::onRightClickBlock);
 
         modContainer.registerConfig(ModConfig.Type.COMMON, GrowthcraftConfig.SPEC);
-    }
-
-    private void commonSetup(FMLCommonSetupEvent event) {
-        LOGGER.info("HELLO FROM COMMON SETUP");
-    }
-
-    // You can use SubscribeEvent and let the Event Bus discover methods to call
-    @SubscribeEvent
-    public void onServerStarting(ServerStartingEvent event) {
-        LOGGER.info("HELLO from server starting");
     }
 }

--- a/src/main/java/growthcraft/core/GrowthcraftClient.java
+++ b/src/main/java/growthcraft/core/GrowthcraftClient.java
@@ -2,13 +2,11 @@ package growthcraft.core;
 
 import growthcraft.core.init.GrowthcraftParticles;
 import growthcraft.lib.client.particle.ColoredDripParticle;
-import net.minecraft.client.Minecraft;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.common.Mod;
-import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
 import net.neoforged.neoforge.client.gui.ConfigurationScreen;
 import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
 import net.neoforged.neoforge.client.event.RegisterParticleProvidersEvent;
@@ -23,13 +21,6 @@ public class GrowthcraftClient {
         // The config screen is accessed by going to the Mods screen > clicking on your mod > clicking on config.
         // Do not forget to add translations for your config options to the en_us.json file.
         container.registerExtensionPoint(IConfigScreenFactory.class, ConfigurationScreen::new);
-    }
-
-    @SubscribeEvent
-    static void onClientSetup(FMLClientSetupEvent event) {
-        // Some client setup code
-        Growthcraft.LOGGER.info("HELLO FROM CLIENT SETUP");
-        Growthcraft.LOGGER.info("MINECRAFT NAME >> {}", Minecraft.getInstance().getUser().getName());
     }
 
     @SubscribeEvent

--- a/src/main/java/growthcraft/core/config/ConfigValueConditionResolver.java
+++ b/src/main/java/growthcraft/core/config/ConfigValueConditionResolver.java
@@ -1,8 +1,12 @@
 package growthcraft.core.config;
 
+import growthcraft.apiary.config.GrowthcraftApiaryConfig;
+import growthcraft.apples.config.GrowthcraftApplesConfig;
+import growthcraft.bamboo.config.GrowthcraftBambooConfig;
 import growthcraft.cellar.config.GrowthcraftCellarConfig;
 import growthcraft.core.Growthcraft;
 import growthcraft.milk.config.GrowthcraftMilkConfig;
+import growthcraft.rice.config.GrowthcraftRiceConfig;
 import net.neoforged.neoforge.common.ModConfigSpec;
 
 import java.util.Arrays;
@@ -11,13 +15,21 @@ import java.util.Map;
 import java.util.Optional;
 
 final class ConfigValueConditionResolver {
-    private static final Map<String, ModConfigSpec> CONFIG_SPECS = Map.of(
-            "core", GrowthcraftConfig.SPEC,
-            "growthcraft", GrowthcraftConfig.SPEC,
-            "cellar", GrowthcraftCellarConfig.SPEC,
-            "growthcraft_cellar", GrowthcraftCellarConfig.SPEC,
-            "milk", GrowthcraftMilkConfig.SPEC,
-            "growthcraft_milk", GrowthcraftMilkConfig.SPEC
+    private static final Map<String, ModConfigSpec> CONFIG_SPECS = Map.ofEntries(
+            Map.entry("core", GrowthcraftConfig.SPEC),
+            Map.entry("growthcraft", GrowthcraftConfig.SPEC),
+            Map.entry("cellar", GrowthcraftCellarConfig.SPEC),
+            Map.entry("growthcraft_cellar", GrowthcraftCellarConfig.SPEC),
+            Map.entry("milk", GrowthcraftMilkConfig.SPEC),
+            Map.entry("growthcraft_milk", GrowthcraftMilkConfig.SPEC),
+            Map.entry("apiary", GrowthcraftApiaryConfig.SPEC),
+            Map.entry("growthcraft_apiary", GrowthcraftApiaryConfig.SPEC),
+            Map.entry("apples", GrowthcraftApplesConfig.SPEC),
+            Map.entry("growthcraft_apples", GrowthcraftApplesConfig.SPEC),
+            Map.entry("bamboo", GrowthcraftBambooConfig.SPEC),
+            Map.entry("growthcraft_bamboo", GrowthcraftBambooConfig.SPEC),
+            Map.entry("rice", GrowthcraftRiceConfig.SPEC),
+            Map.entry("growthcraft_rice", GrowthcraftRiceConfig.SPEC)
     );
 
     private ConfigValueConditionResolver() {}

--- a/src/main/java/growthcraft/core/config/GrowthcraftConfig.java
+++ b/src/main/java/growthcraft/core/config/GrowthcraftConfig.java
@@ -48,6 +48,22 @@ public class GrowthcraftConfig {
             .comment("Number of salt ore veins per chunk (spread amount).")
             .defineInRange(String.format("%s.%s", CATEGORY_WORLDGEN, "saltOreGenSpreadAmount"), 10, 1, 20);
 
+    private static final ModConfigSpec.BooleanValue debugEnabled = SERVER_BUILDER
+            .comment("Set to true to add additional Growthcraft Core debug logging.")
+            .define("debug.enabled", false);
+
+    private static final ModConfigSpec.BooleanValue worldgenDebugEnabled = SERVER_BUILDER
+            .comment("Set to true to add additional debug logging for Growthcraft Core world generation.")
+            .define("debug.worldgen.enabled", false);
+
+    private static final ModConfigSpec.BooleanValue ropesDebugEnabled = SERVER_BUILDER
+            .comment("Set to true to add additional debug logging for Growthcraft ropes and rope fences.")
+            .define("debug.ropes.enabled", false);
+
+    private static final ModConfigSpec.BooleanValue shopSignsDebugEnabled = SERVER_BUILDER
+            .comment("Set to true to add additional debug logging for Growthcraft shop sign transforms.")
+            .define("debug.shop_signs.enabled", false);
+
     private static ModConfigSpec.BooleanValue crowbarsEnabled; // Placeholder for future config
 
     public static final ModConfigSpec SPEC = SERVER_BUILDER.build();
@@ -61,6 +77,10 @@ public class GrowthcraftConfig {
     public static int saltOreHeightMin() { return saltOreGenHeightMin.get(); }
     public static int saltOreHeightMax() { return saltOreGenHeightMax.get(); }
     public static int saltOreSpreadAmount() { return saltOreGenSpreadAmount.get(); }
+    public static boolean isDebugEnabled() { return debugEnabled.get(); }
+    public static boolean isWorldgenDebugEnabled() { return worldgenDebugEnabled.get(); }
+    public static boolean isRopesDebugEnabled() { return ropesDebugEnabled.get(); }
+    public static boolean isShopSignsDebugEnabled() { return shopSignsDebugEnabled.get(); }
 
     private static boolean validateItemName(final Object obj) {
         return obj instanceof String itemName && BuiltInRegistries.ITEM.containsKey(ResourceLocation.parse(itemName));

--- a/src/main/java/growthcraft/milk/GrowthcraftMilk.java
+++ b/src/main/java/growthcraft/milk/GrowthcraftMilk.java
@@ -13,14 +13,10 @@ import growthcraft.milk.init.GrowthcraftMilkMenus;
 import growthcraft.milk.init.GrowthcraftMilkRecipes;
 import net.minecraft.world.item.CreativeModeTab;
 import net.neoforged.bus.api.IEventBus;
-import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.config.ModConfig;
-import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
-import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
-import net.neoforged.neoforge.event.server.ServerStartingEvent;
 import org.slf4j.Logger;
 
 /**
@@ -33,9 +29,6 @@ public class GrowthcraftMilk {
     public static final Logger LOGGER = LogUtils.getLogger();
 
     public GrowthcraftMilk(IEventBus modEventBus, ModContainer modContainer) {
-        // Register lifecycle listeners
-        modEventBus.addListener(this::commonSetup);
-
         // Register all Milk module registries
         GrowthcraftMilkBlocks.BLOCKS.register(modEventBus);
         GrowthcraftMilkItems.ITEMS.register(modEventBus);
@@ -51,17 +44,10 @@ public class GrowthcraftMilk {
         modEventBus.addListener(this::buildCreativeTab);
         modEventBus.addListener(GrowthcraftMilkCapabilities::registerCapabilities);
 
-        // Register to the global event bus for general events
-        NeoForge.EVENT_BUS.register(this);
-
         // Register module config
         modContainer.registerConfig(ModConfig.Type.COMMON, GrowthcraftMilkConfig.SPEC);
 
         LOGGER.info("Growthcraft Milk module initialized");
-    }
-
-    private void commonSetup(FMLCommonSetupEvent event) {
-        LOGGER.info("[{}] Common setup", Reference.NAME);
     }
 
     private void buildCreativeTab(BuildCreativeModeTabContentsEvent event) {
@@ -167,10 +153,5 @@ public class GrowthcraftMilk {
                 }
             }
         }
-    }
-
-    @SubscribeEvent
-    public void onServerStarting(ServerStartingEvent event) {
-        LOGGER.info("[{}] Server starting hook", Reference.NAME);
     }
 }

--- a/src/main/java/growthcraft/milk/config/GrowthcraftMilkConfig.java
+++ b/src/main/java/growthcraft/milk/config/GrowthcraftMilkConfig.java
@@ -16,11 +16,18 @@ public final class GrowthcraftMilkConfig {
     private static ModConfigSpec.BooleanValue featureEnabledBeverages; // _master_switch_.feature_exception_beverages
 
     // GUIs and debug
+    private static ModConfigSpec.BooleanValue debugEnabled;             // debug.enabled
     private static ModConfigSpec.BooleanValue churnGuiEnabled;           // churn.guiEnabled
+    private static ModConfigSpec.BooleanValue churnDebugEnabled;         // churn.debugEnabled
     private static ModConfigSpec.BooleanValue pancheonGuiEnabled;        // pancheon.guiEnabled
+    private static ModConfigSpec.BooleanValue pancheonDebugEnabled;      // pancheon.debugEnabled
     private static ModConfigSpec.BooleanValue mixingVatGuiEnabled;       // mixing_vat.guiEnabled
     private static ModConfigSpec.BooleanValue mixingVatDebugEnabled;     // mixing_vat.debugEnabled
     private static ModConfigSpec.BooleanValue mixingVatConsumeActivator; // mixing_vat.consumeMixingVatActivator
+    private static ModConfigSpec.BooleanValue bucketsDebugEnabled;        // buckets.debugEnabled
+    private static ModConfigSpec.BooleanValue cheesePressDebugEnabled;   // cheese_press.debugEnabled
+    private static ModConfigSpec.BooleanValue capabilitiesDebugEnabled;   // capabilities.debugEnabled
+    private static ModConfigSpec.BooleanValue shopSignsDebugEnabled;      // shop_signs.debugEnabled
 
     // Loot
     private static ModConfigSpec.BooleanValue stomachLootEnabled;        // loot_modifiers.stomachLootEnabled
@@ -40,11 +47,21 @@ public final class GrowthcraftMilkConfig {
                 .define("feature_exception_beverages", true);
         SERVER_BUILDER.pop();
 
+        // Module debug
+        SERVER_BUILDER.push("debug");
+        debugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional Growthcraft Milk debug logging.")
+                .define("enabled", false);
+        SERVER_BUILDER.pop();
+
         // Churn
         SERVER_BUILDER.push("churn");
         churnGuiEnabled = SERVER_BUILDER
                 .comment("Set to true to allow users to access the Churn GUI.")
                 .define("guiEnabled", true);
+        churnDebugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional logging to debug the Churn.")
+                .define("debugEnabled", false);
         SERVER_BUILDER.pop();
 
         // Mixing Vat
@@ -65,6 +82,23 @@ public final class GrowthcraftMilkConfig {
         pancheonGuiEnabled = SERVER_BUILDER
                 .comment("Set to true to allow users to access the Pancheon GUI.")
                 .define("guiEnabled", true);
+        pancheonDebugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional logging to debug the Pancheon.")
+                .define("debugEnabled", false);
+        SERVER_BUILDER.pop();
+
+        // Buckets
+        SERVER_BUILDER.push("buckets");
+        bucketsDebugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional logging to debug Growthcraft Milk bucket interactions.")
+                .define("debugEnabled", false);
+        SERVER_BUILDER.pop();
+
+        // Cheese Press
+        SERVER_BUILDER.push("cheese_press");
+        cheesePressDebugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional logging to debug the Cheese Press.")
+                .define("debugEnabled", false);
         SERVER_BUILDER.pop();
 
         // Loot Modifiers
@@ -84,6 +118,20 @@ public final class GrowthcraftMilkConfig {
                 .define("debugEnabled", false);
         SERVER_BUILDER.pop();
 
+        // Capabilities
+        SERVER_BUILDER.push("capabilities");
+        capabilitiesDebugEnabled = SERVER_BUILDER
+                .comment("Set to true to log Milk capability registration details.")
+                .define("debugEnabled", false);
+        SERVER_BUILDER.pop();
+
+        // Shop Signs
+        SERVER_BUILDER.push("shop_signs");
+        shopSignsDebugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional logging to debug Milk shop sign behavior.")
+                .define("debugEnabled", false);
+        SERVER_BUILDER.pop();
+
         SPEC = SERVER_BUILDER.build();
     }
 
@@ -91,16 +139,23 @@ public final class GrowthcraftMilkConfig {
     public static boolean getModuleEnabled() { return moduleEnabled.get(); }
     public static boolean getFeatureEnabledBeverages() { return featureEnabledBeverages.get(); }
 
+    public static boolean isDebugEnabled() { return debugEnabled.get(); }
     public static boolean isChurnGuiEnabled() { return churnGuiEnabled.get(); }
+    public static boolean isChurnDebugEnabled() { return churnDebugEnabled.get(); }
     public static boolean isPancheonGuiEnabled() { return pancheonGuiEnabled.get(); }
+    public static boolean isPancheonDebugEnabled() { return pancheonDebugEnabled.get(); }
     public static boolean isMixingVatGuiEnabled() { return mixingVatGuiEnabled.get(); }
     public static boolean isMixingDebugEnabled() { return mixingVatDebugEnabled.get(); }
     public static boolean isConsumeMixingVatActivator() { return mixingVatConsumeActivator.get(); }
+    public static boolean isBucketsDebugEnabled() { return bucketsDebugEnabled.get(); }
+    public static boolean isCheesePressDebugEnabled() { return cheesePressDebugEnabled.get(); }
 
     public static boolean isStomachLootingEnabled() { return stomachLootEnabled.get(); }
     public static int getStomachLootChance() { return Boolean.TRUE.equals(stomachLootEnabled.get()) ? stomachLootChance.get() : 0; }
 
     public static boolean isCheeseDebugEnabled() { return cheeseDebugEnabled.get(); }
+    public static boolean isCapabilitiesDebugEnabled() { return capabilitiesDebugEnabled.get(); }
+    public static boolean isShopSignsDebugEnabled() { return shopSignsDebugEnabled.get(); }
 
     private GrowthcraftMilkConfig() {}
 }

--- a/src/main/java/growthcraft/milk/item/GrowthcraftMilkBucketItem.java
+++ b/src/main/java/growthcraft/milk/item/GrowthcraftMilkBucketItem.java
@@ -1,5 +1,7 @@
 package growthcraft.milk.item;
 
+import growthcraft.milk.GrowthcraftMilk;
+import growthcraft.milk.config.GrowthcraftMilkConfig;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.player.Player;
@@ -19,6 +21,12 @@ import java.util.function.Supplier;
 public class GrowthcraftMilkBucketItem extends BucketItem {
     private final Supplier<Item> emptyReturn;
 
+    private static void debug(String message, Object... args) {
+        if (GrowthcraftMilkConfig.isBucketsDebugEnabled()) {
+            GrowthcraftMilk.LOGGER.debug(message, args);
+        }
+    }
+
     public GrowthcraftMilkBucketItem(Fluid content, Supplier<Item> emptyReturn, Properties properties) {
         super(content, properties);
         this.emptyReturn = emptyReturn;
@@ -29,14 +37,14 @@ public class GrowthcraftMilkBucketItem extends BucketItem {
         InteractionResultHolder<ItemStack> ret = super.use(level, player, hand);
         if (!level.isClientSide && ret.getResult().consumesAction()) {
             ItemStack out = ret.getObject();
-            growthcraft.milk.GrowthcraftMilk.LOGGER.debug("[MilkBucket] use(Server): Player={} Hand={} ResultActionConsumed outItem={} Creative?={} -> replacing with emptyReturn={}",
+            debug("[MilkBucket] use(Server): Player={} Hand={} ResultActionConsumed outItem={} Creative?={} -> replacing with emptyReturn={}",
                     player.getGameProfile().getName(), hand, out.getItem(), player.getAbilities().instabuild, this.emptyReturn.get());
             if (!player.getAbilities().instabuild) {
                 // Replace vanilla empty bucket with our designated empty return
                 return InteractionResultHolder.sidedSuccess(new ItemStack(this.emptyReturn.get()), level.isClientSide);
             }
         } else if (level.isClientSide) {
-            growthcraft.milk.GrowthcraftMilk.LOGGER.debug("[MilkBucket] use(Client): deferring to server. Player={} Hand={}", player.getGameProfile().getName(), hand);
+            debug("[MilkBucket] use(Client): deferring to server. Player={} Hand={}", player.getGameProfile().getName(), hand);
         }
         return ret;
     }

--- a/src/main/java/growthcraft/milk/item/MilkingBucketItem.java
+++ b/src/main/java/growthcraft/milk/item/MilkingBucketItem.java
@@ -1,5 +1,7 @@
 package growthcraft.milk.item;
 
+import growthcraft.milk.GrowthcraftMilk;
+import growthcraft.milk.config.GrowthcraftMilkConfig;
 import growthcraft.milk.init.GrowthcraftMilkFluids;
 import growthcraft.milk.init.GrowthcraftMilkTags;
 import net.minecraft.advancements.CriteriaTriggers;
@@ -40,6 +42,12 @@ import java.util.function.Supplier;
 public class MilkingBucketItem extends Item implements DispensibleContainerItem {
     private final Supplier<? extends Fluid> fluidSupplier;
 
+    private static void debug(String message, Object... args) {
+        if (GrowthcraftMilkConfig.isBucketsDebugEnabled()) {
+            GrowthcraftMilk.LOGGER.debug(message, args);
+        }
+    }
+
     public MilkingBucketItem(Supplier<? extends Fluid> fluidSupplier, Properties properties) {
         super(properties);
         this.fluidSupplier = fluidSupplier;
@@ -55,12 +63,12 @@ public class MilkingBucketItem extends Item implements DispensibleContainerItem 
         // Check tag first, then fallback to vanilla cow
         EntityType<?> type = target.getType();
         boolean milkable = type.is(GrowthcraftMilkTags.EntityTypes.MILKABLE) || target instanceof Cow;
-        growthcraft.milk.GrowthcraftMilk.LOGGER.debug("[MilkingBucket] interactLivingEntity(Server): Player={} Target={} Milkable?={} StackCount={} Hand={}",
+        debug("[MilkingBucket] interactLivingEntity(Server): Player={} Target={} Milkable?={} StackCount={} Hand={}",
                 player.getGameProfile().getName(), type.toShortString(), milkable, stack.getCount(), hand);
         if (milkable) {
             ItemStack milkBucket = new ItemStack(growthcraft.milk.init.GrowthcraftMilkItems.MILK_BUCKET_IRON.get());
             boolean added = player.getInventory().add(milkBucket);
-            growthcraft.milk.GrowthcraftMilk.LOGGER.debug("[MilkingBucket] Milking result: created {} addedToInv?={} (will drop if false)", milkBucket.getItem(), added);
+            debug("[MilkingBucket] Milking result: created {} addedToInv?={} (will drop if false)", milkBucket.getItem(), added);
             if (!added) {
                 player.drop(milkBucket, false);
             }

--- a/src/main/java/growthcraft/rice/GrowthcraftRice.java
+++ b/src/main/java/growthcraft/rice/GrowthcraftRice.java
@@ -2,13 +2,16 @@ package growthcraft.rice;
 
 import com.mojang.logging.LogUtils;
 import growthcraft.core.init.GrowthcraftCreativeTabs;
+import growthcraft.rice.config.GrowthcraftRiceConfig;
 import growthcraft.rice.config.Reference;
 import growthcraft.rice.init.GrowthcraftRiceBlocks;
 import growthcraft.rice.init.GrowthcraftRiceFluids;
 import growthcraft.rice.init.GrowthcraftRiceItems;
 import net.minecraft.world.item.CreativeModeTab;
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.config.ModConfig;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
 import org.slf4j.Logger;
 
@@ -17,13 +20,15 @@ public class GrowthcraftRice {
     public static final String MODID = Reference.MODID;
     public static final Logger LOGGER = LogUtils.getLogger();
 
-    public GrowthcraftRice(IEventBus modEventBus) {
+    public GrowthcraftRice(IEventBus modEventBus, ModContainer modContainer) {
         GrowthcraftRiceBlocks.BLOCKS.register(modEventBus);
         GrowthcraftRiceItems.ITEMS.register(modEventBus);
         GrowthcraftRiceFluids.FLUID_TYPES.register(modEventBus);
         GrowthcraftRiceFluids.FLUIDS.register(modEventBus);
         GrowthcraftRiceFluids.BLOCKS.register(modEventBus);
         modEventBus.addListener(this::buildCreativeTab);
+
+        modContainer.registerConfig(ModConfig.Type.COMMON, GrowthcraftRiceConfig.SPEC);
 
         LOGGER.info("{} module initialized", Reference.NAME);
     }

--- a/src/main/java/growthcraft/rice/config/GrowthcraftRiceConfig.java
+++ b/src/main/java/growthcraft/rice/config/GrowthcraftRiceConfig.java
@@ -1,0 +1,49 @@
+package growthcraft.rice.config;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+public final class GrowthcraftRiceConfig {
+    private static final ModConfigSpec.Builder SERVER_BUILDER = new ModConfigSpec.Builder();
+
+    public static final ModConfigSpec SPEC;
+
+    private static ModConfigSpec.BooleanValue debugEnabled;
+    private static ModConfigSpec.BooleanValue cropsDebugEnabled;
+    private static ModConfigSpec.BooleanValue fluidsDebugEnabled;
+
+    static {
+        SERVER_BUILDER.push("debug");
+        debugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional Growthcraft Rice debug logging.")
+                .define("enabled", false);
+        SERVER_BUILDER.pop();
+
+        SERVER_BUILDER.push("crops");
+        cropsDebugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional debug logging for Rice crops and cultivated farmland.")
+                .define("debugEnabled", false);
+        SERVER_BUILDER.pop();
+
+        SERVER_BUILDER.push("fluids");
+        fluidsDebugEnabled = SERVER_BUILDER
+                .comment("Set to true to add additional debug logging for Rice fluids.")
+                .define("debugEnabled", false);
+        SERVER_BUILDER.pop();
+
+        SPEC = SERVER_BUILDER.build();
+    }
+
+    public static boolean isDebugEnabled() {
+        return debugEnabled.get();
+    }
+
+    public static boolean isCropsDebugEnabled() {
+        return cropsDebugEnabled.get();
+    }
+
+    public static boolean isFluidsDebugEnabled() {
+        return fluidsDebugEnabled.get();
+    }
+
+    private GrowthcraftRiceConfig() {}
+}


### PR DESCRIPTION
## What changed

- Removed leftover startup/client/server debug lifecycle logging from Growthcraft core, Cellar, and Milk.
- Routed existing noisy Culture Jar and Milk bucket debug logs behind disabled-by-default config toggles.
- Prestaged disabled-by-default debug config toggles across Growthcraft modules and machine/block families.
- Added common config registration for Rice, Bamboo, Apples, and Apiary so future debug logging has a consistent home.
- Extended config-value recipe condition lookup to include the newly registered module configs.

## Why

Issue #125 called out startup debug noise. While testing in IntelliJ DEBUG logging, the old unconditional messages and Culture Jar traces were the risky part: they made real issues harder to spot. The new config toggles keep debug logging available when we need it without making normal startup and gameplay logs noisy.

## Validation

- Ran `./gradlew.bat build` successfully.
- Started the game from IntelliJ with DEBUG logging enabled.
- Checked `run/logs/latest.log` and `run/logs/debug.log` for Growthcraft-owned debug noise.
- Confirmed only normal module init messages remained; JEI still emits its own recipe-registration DEBUG logs.

Closes #125
