### PR TITLE
Add rice stalks as ruminant feed

### DIFF
--- a/src/main/resources/data/minecraft/tags/item/cow_food.json
+++ b/src/main/resources/data/minecraft/tags/item/cow_food.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "growthcraft_rice:rice_stalk"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/item/goat_food.json
+++ b/src/main/resources/data/minecraft/tags/item/goat_food.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "growthcraft_rice:rice_stalk"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/item/sheep_food.json
+++ b/src/main/resources/data/minecraft/tags/item/sheep_food.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "growthcraft_rice:rice_stalk"
+  ]
+}


### PR DESCRIPTION
## What changed

- Added `growthcraft_rice:rice_stalk` to the vanilla cow, sheep, and goat food tags.
- Left pigs, chickens, and horses unchanged.

## Why

Rice stalks fit best as low-value roughage rather than general animal food. Cows, sheep, and goats are the most believable targets because they can eat fibrous forage/straw-like material. Pigs and chickens do not make much sense for stalks, and horses felt less obvious than the ruminants, so this keeps the behavior conservative.

## Validation

- Ran `./gradlew.bat build` successfully.
- Manually tested in game and confirmed the behavior works as expected.

Closes #139
