### PR TITLE
Show fermented fluid names on filled drinks

### DIFF
--- a/src/main/java/growthcraft/cellar/recipe/FermentationBarrelRecipe.java
+++ b/src/main/java/growthcraft/cellar/recipe/FermentationBarrelRecipe.java
@@ -10,7 +10,6 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
-import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.util.ExtraCodecs;
@@ -95,8 +94,8 @@ public class FermentationBarrelRecipe implements Recipe<FermentationBarrelInput>
 
         var fluid = BuiltInRegistries.FLUID.get(result.fluidId());
         if (fluid != Fluids.EMPTY) {
-            Component fluidName = new FluidStack(fluid, Math.max(1, result.amount())).getHoverName();
-            stack.set(DataComponents.CUSTOM_NAME, Component.translatable(stack.getDescriptionId(), fluidName));
+            stack.set(DataComponents.CUSTOM_NAME,
+                    new FluidStack(fluid, Math.max(1, result.amount())).getHoverName());
         }
 
         List<MobEffectInstance> potionEffects = effects.stream()


### PR DESCRIPTION
﻿## Summary
- name filled fermentation containers after the recipe's result fluid
- preserve the configured bottle or pint-glass item
- preserve potion effects, color, and other item components

## Root cause
The recipe passed the fermented fluid name as an argument to the container item's translation component. Container keys such as `Pint Glass (Lager)` do not contain a substitution placeholder, so Minecraft ignored the fluid-name argument and displayed the generic container name.

## Validation
- `./gradlew.bat compileJava -x createMinecraftArtifacts`
- `./gradlew.bat test -x createMinecraftArtifacts`
- `git diff --check`
- manually confirmed a filled lager pint glass displays the fermented fluid name while retaining its effects and container

Closes #200
