### PR TITLE
Share heat-source detection across machines

### DIFF
--- a/src/main/java/growthcraft/cellar/block/BrewKettleBlock.java
+++ b/src/main/java/growthcraft/cellar/block/BrewKettleBlock.java
@@ -1,13 +1,9 @@
 package growthcraft.cellar.block;
 
 import growthcraft.cellar.block.entity.BrewKettleBlockEntity;
-import growthcraft.cellar.config.Reference;
+import growthcraft.lib.utils.HeatSourceUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.tags.FluidTags;
-import net.minecraft.tags.TagKey;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.world.Containers;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -17,7 +13,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.HorizontalDirectionalBlock;
 import net.minecraft.world.level.block.Mirror;
@@ -29,11 +24,8 @@ import net.minecraft.world.level.block.entity.BlockEntityTicker;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
-import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.DirectionProperty;
-import net.minecraft.world.level.material.FluidState;
-import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.level.material.PushReaction;
 import net.minecraft.world.phys.BlockHitResult;
@@ -48,7 +40,6 @@ public class BrewKettleBlock extends Block implements EntityBlock {
     public static final DirectionProperty FACING = HorizontalDirectionalBlock.FACING;
     public static final BooleanProperty LIT = BooleanProperty.create("lit");
     public static final BooleanProperty HAS_LID = BooleanProperty.create("has_lid");
-    private static final TagKey<Block> HEAT_SOURCE_TAG = TagKey.create(Registries.BLOCK, ResourceLocation.fromNamespaceAndPath(Reference.MODID, Reference.UnlocalizedName.Tag.HEATSOURCES));
 
     public BrewKettleBlock() {
         super(Properties.of()
@@ -162,14 +153,7 @@ public class BrewKettleBlock extends Block implements EntityBlock {
     }
 
     private static boolean hasHeatSourceBelow(Level level, BlockPos pos) {
-        BlockPos below = pos.below();
-        BlockState state = level.getBlockState(below);
-        if (state.is(HEAT_SOURCE_TAG)) return true;
-        if (state.is(Blocks.MAGMA_BLOCK) || state.is(Blocks.FIRE) || state.is(Blocks.SOUL_FIRE)) return true;
-        if (state.hasProperty(BlockStateProperties.LIT) && Boolean.TRUE.equals(state.getValue(BlockStateProperties.LIT))) return true;
-
-        FluidState fluid = level.getFluidState(below);
-        return !fluid.isEmpty() && (fluid.is(FluidTags.LAVA) || fluid.getType() == Fluids.LAVA);
+        return HeatSourceUtils.hasHeatSourceBelow(level, pos);
     }
 
     @Override

--- a/src/main/java/growthcraft/cellar/block/CultureJarBlock.java
+++ b/src/main/java/growthcraft/cellar/block/CultureJarBlock.java
@@ -4,6 +4,7 @@ import com.mojang.serialization.MapCodec;
 import growthcraft.cellar.GrowthcraftCellar;
 import growthcraft.cellar.block.entity.CultureJarBlockEntity;
 import growthcraft.cellar.config.GrowthcraftCellarConfig;
+import growthcraft.lib.utils.HeatSourceUtils;
 import growthcraft.milk.item.GrowthcraftMilkBucketItem;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -27,15 +28,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.material.FluidState;
-import net.minecraft.world.level.material.Fluids;
-import net.minecraft.tags.FluidTags;
-import net.minecraft.core.registries.Registries;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.TagKey;
 import net.minecraft.world.phys.BlockHitResult;
-import growthcraft.cellar.config.Reference;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.neoforged.neoforge.fluids.FluidUtil;
@@ -50,8 +43,6 @@ public class CultureJarBlock extends HorizontalDirectionalBlock implements Entit
         }
     }
     public static final MapCodec<CultureJarBlock> CODEC = simpleCodec(CultureJarBlock::new);
-
-    private static final TagKey<Block> HEAT_SOURCE_TAG = TagKey.create(Registries.BLOCK, ResourceLocation.fromNamespaceAndPath(Reference.MODID, Reference.UnlocalizedName.Tag.HEATSOURCES));
 
     // Reduced bounding box to better match the jar model footprint and height
     private static final VoxelShape SHAPE = Block.box(5.0D, 0.0D, 5.0D, 11.0D, 8.0D, 11.0D);
@@ -104,25 +95,10 @@ public class CultureJarBlock extends HorizontalDirectionalBlock implements Entit
                     int r2 = dx*dx + dy*dy + dz*dz;
                     if (r2 > 4) continue; // outside radius 2
                     BlockPos checkPos = pos.offset(dx, dy, dz);
-                    BlockState bs = level.getBlockState(checkPos);
-                    if (isHeatSourceBlock(level, checkPos, bs)) return true;
+                    if (HeatSourceUtils.isHeatSource(level, checkPos)) return true;
                 }
             }
         }
-        return false;
-    }
-
-    private static boolean isHeatSourceBlock(Level level, BlockPos pos, BlockState state) {
-        // Prefer tag first so packs/mods can extend
-        if (state.is(HEAT_SOURCE_TAG)) return true;
-        // Vanilla/common heat sources
-        if (state.is(Blocks.MAGMA_BLOCK)) return true;
-        if (state.is(Blocks.FIRE) || state.is(Blocks.SOUL_FIRE)) return true;
-        // Any lit block with LIT=true (covers furnaces, blast/smoker, campfires, candles when lit)
-        if (state.hasProperty(BlockStateProperties.LIT) && Boolean.TRUE.equals(state.getValue(BlockStateProperties.LIT))) return true;
-        // Lava source or flowing
-        FluidState fluid = level.getFluidState(pos);
-        if (!fluid.isEmpty() && (fluid.is(FluidTags.LAVA) || fluid.getType() == Fluids.LAVA)) return true;
         return false;
     }
 

--- a/src/main/java/growthcraft/cellar/block/RoasterBlock.java
+++ b/src/main/java/growthcraft/cellar/block/RoasterBlock.java
@@ -1,7 +1,7 @@
 package growthcraft.cellar.block;
 
 import growthcraft.cellar.block.entity.RoasterBlockEntity;
-import growthcraft.cellar.config.Reference;
+import growthcraft.lib.utils.HeatSourceUtils;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
@@ -17,7 +17,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.HorizontalDirectionalBlock;
 import net.minecraft.world.level.block.Mirror;
@@ -27,17 +26,13 @@ import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityTicker;
 import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
-import net.minecraft.world.level.material.FluidState;
-import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.level.material.PushReaction;
-import net.minecraft.tags.FluidTags;
 import net.minecraft.world.phys.BlockHitResult;
 import org.jetbrains.annotations.Nullable;
 
@@ -45,7 +40,6 @@ public class RoasterBlock extends Block implements EntityBlock {
     public static final DirectionProperty FACING = HorizontalDirectionalBlock.FACING;
     public static final BooleanProperty LIT = BooleanProperty.create("lit");
     public static final IntegerProperty ROASTING_LEVEL = IntegerProperty.create("roasting_level", 1, 8);
-    private static final TagKey<Block> HEAT_SOURCE_TAG = TagKey.create(Registries.BLOCK, ResourceLocation.fromNamespaceAndPath(Reference.MODID, Reference.UnlocalizedName.Tag.HEATSOURCES));
     private static final TagKey<net.minecraft.world.item.Item> WRENCH_TAG = TagKey.create(Registries.ITEM, ResourceLocation.fromNamespaceAndPath("c", "tools/wrench"));
 
     public RoasterBlock() {
@@ -147,14 +141,7 @@ public class RoasterBlock extends Block implements EntityBlock {
     }
 
     private static boolean hasHeatSourceBelow(Level level, BlockPos pos) {
-        BlockPos below = pos.below();
-        BlockState state = level.getBlockState(below);
-        if (state.is(HEAT_SOURCE_TAG)) return true;
-        if (state.is(Blocks.MAGMA_BLOCK) || state.is(Blocks.FIRE) || state.is(Blocks.SOUL_FIRE)) return true;
-        if (state.hasProperty(BlockStateProperties.LIT) && Boolean.TRUE.equals(state.getValue(BlockStateProperties.LIT))) return true;
-
-        FluidState fluid = level.getFluidState(below);
-        return !fluid.isEmpty() && (fluid.is(FluidTags.LAVA) || fluid.getType() == Fluids.LAVA);
+        return HeatSourceUtils.hasHeatSourceBelow(level, pos);
     }
 
     private static boolean isWrench(ItemStack stack) {

--- a/src/main/java/growthcraft/lib/utils/HeatSourceUtils.java
+++ b/src/main/java/growthcraft/lib/utils/HeatSourceUtils.java
@@ -1,0 +1,44 @@
+package growthcraft.lib.utils;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.FluidTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.level.material.Fluids;
+
+public final class HeatSourceUtils {
+    public static final TagKey<Block> HEAT_SOURCES = TagKey.create(Registries.BLOCK,
+            ResourceLocation.fromNamespaceAndPath("growthcraft_cellar", "heat_sources"));
+
+    private HeatSourceUtils() {}
+
+    public static boolean hasHeatSourceBelow(Level level, BlockPos pos) {
+        return level != null && isHeatSource(level, pos.below());
+    }
+
+    public static boolean isHeatSource(Level level, BlockPos pos) {
+        if (level == null) return false;
+
+        BlockState state = level.getBlockState(pos);
+        if (state.is(HEAT_SOURCES)
+                || state.is(Blocks.MAGMA_BLOCK)
+                || state.is(Blocks.FIRE)
+                || state.is(Blocks.SOUL_FIRE)) {
+            return true;
+        }
+        if (state.hasProperty(BlockStateProperties.LIT)
+                && Boolean.TRUE.equals(state.getValue(BlockStateProperties.LIT))) {
+            return true;
+        }
+
+        FluidState fluid = level.getFluidState(pos);
+        return !fluid.isEmpty() && (fluid.is(FluidTags.LAVA) || fluid.getType() == Fluids.LAVA);
+    }
+}

--- a/src/main/java/growthcraft/milk/block/entity/MixingVatBlockEntity.java
+++ b/src/main/java/growthcraft/milk/block/entity/MixingVatBlockEntity.java
@@ -6,6 +6,7 @@ import growthcraft.milk.init.GrowthcraftMilkRecipes;
 import growthcraft.milk.menu.MixingVatMenu;
 import growthcraft.milk.recipe.MixingVatRecipe;
 import growthcraft.milk.recipe.input.MixingVatInput;
+import growthcraft.lib.utils.HeatSourceUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
@@ -258,15 +259,7 @@ public class MixingVatBlockEntity extends BlockEntity implements WorldlyContaine
     }
 
     public static boolean isHeated(Level level, BlockPos pos) {
-        if (level == null) {
-            return false;
-        }
-        BlockState below = level.getBlockState(pos.below());
-        return below.is(net.minecraft.world.level.block.Blocks.FIRE)
-                || below.is(net.minecraft.world.level.block.Blocks.SOUL_FIRE)
-                || below.is(net.minecraft.world.level.block.Blocks.MAGMA_BLOCK)
-                || (below.hasProperty(net.minecraft.world.level.block.state.properties.BlockStateProperties.LIT)
-                        && Boolean.TRUE.equals(below.getValue(net.minecraft.world.level.block.state.properties.BlockStateProperties.LIT)));
+        return HeatSourceUtils.hasHeatSourceBelow(level, pos);
     }
 
     public boolean isProcessing() {


### PR DESCRIPTION
﻿## Summary
- centralize heat-source classification in `HeatSourceUtils`
- make Mixing Vat honor the same `growthcraft_cellar:heat_sources` block tag as the Cellar machines
- reuse the helper from Brew Kettle, Roaster, and Culture Jar to remove duplicated classification logic
- preserve each machine's existing search geometry: directly below for Vat/Kettle/Roaster and radius two for Culture Jar

## Root cause
Mixing Vat maintained a separate hard-coded heat check. It recognized several vanilla blocks but ignored datapack additions to the established heat-source tag and did not share the lava fallback used by the Cellar machines.

## Validation
- `./gradlew.bat compileJava -x createMinecraftArtifacts`
- `./gradlew.bat test -x createMinecraftArtifacts`
- `git diff --check`
- manually added `minecraft:diamond_block` to `growthcraft_cellar:heat_sources` through a temporary datapack and confirmed the machines detected it as expected

Closes #196
