### PR TITLE
Fix Cork Coaster synchronization and support

### DIFF
--- a/src/main/java/growthcraft/cellar/block/CorkCoasterBlock.java
+++ b/src/main/java/growthcraft/cellar/block/CorkCoasterBlock.java
@@ -13,6 +13,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
@@ -93,6 +94,14 @@ public class CorkCoasterBlock extends HorizontalDirectionalBlock implements Enti
                 && top.max(Direction.Axis.X) >= 12.0D / 16.0D
                 && top.min(Direction.Axis.Z) <= 4.0D / 16.0D
                 && top.max(Direction.Axis.Z) >= 12.0D / 16.0D;
+    }
+
+    @Override
+    protected BlockState updateShape(BlockState state, Direction direction, BlockState neighborState, LevelAccessor level,
+                                     BlockPos pos, BlockPos neighborPos) {
+        return !state.canSurvive(level, pos)
+                ? Blocks.AIR.defaultBlockState()
+                : super.updateShape(state, direction, neighborState, level, pos, neighborPos);
     }
 
     @Override

--- a/src/main/java/growthcraft/cellar/block/entity/CorkCoasterBlockEntity.java
+++ b/src/main/java/growthcraft/cellar/block/entity/CorkCoasterBlockEntity.java
@@ -16,6 +16,7 @@ import net.minecraft.world.ContainerHelper;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
@@ -94,9 +95,9 @@ public class CorkCoasterBlockEntity extends BlockEntity implements Container, Cl
             BlockState updatedState = state.setValue(CorkCoasterBlock.ITEM, !isEmpty());
             if (state != updatedState) {
                 level.setBlock(worldPosition, updatedState, 3);
-            } else {
-                level.sendBlockUpdated(worldPosition, state, state, 3);
             }
+            BlockState currentState = getBlockState();
+            level.sendBlockUpdated(worldPosition, currentState, currentState, Block.UPDATE_CLIENTS);
         }
     }
 
@@ -111,6 +112,7 @@ public class CorkCoasterBlockEntity extends BlockEntity implements Container, Cl
     @Override
     public void loadAdditional(CompoundTag tag, HolderLookup.Provider provider) {
         super.loadAdditional(tag, provider);
+        items.clear();
         ContainerHelper.loadAllItems(tag.getCompound(ITEMS_TAG), this.items, provider);
     }
 


### PR DESCRIPTION
﻿## Summary
- synchronize Cork Coaster block-entity inventory changes after a player retrieves a bottle
- clear stale client inventory contents before applying an empty update tag
- break Cork Coasters when their supporting surface becomes invalid
- preserve normal coaster and stored-bottle drops when support is removed

## Root causes
The bottle renderer reads the coaster block entity, but the state-change path did not always send the updated block-entity contents. The client also retained its old one-slot contents when an empty update tag was loaded.

The coaster already implemented `canSurvive`, but did not reevaluate that rule during neighbor shape updates, allowing unsupported coasters to float.

## Validation
- `./gradlew.bat compileJava -x createMinecraftArtifacts`
- `./gradlew.bat test -x createMinecraftArtifacts`
- `git diff --check`
- manually confirmed retrieving a bottle removes its rendered model immediately without relogging
- manually confirmed removing support breaks the coaster and drops the coaster and stored bottle exactly once

Closes #199
Closes #198
