### PR TITLE
Correct fermented drink colors

### DIFF
--- a/src/main/resources/data/growthcraft_apiary/recipe/fermentation_barrel_honey_mead.json
+++ b/src/main/resources/data/growthcraft_apiary/recipe/fermentation_barrel_honey_mead.json
@@ -23,5 +23,5 @@
   "bottle": {
     "item": "growthcraft_cellar:potion_wine"
   },
-  "color": "0xE5C7A2"
+  "color": "0xD79334"
 }

--- a/src/main/resources/data/growthcraft_apples/recipe/fermentation_barrel_apple_cider.json
+++ b/src/main/resources/data/growthcraft_apples/recipe/fermentation_barrel_apple_cider.json
@@ -23,5 +23,5 @@
   "bottle": {
     "item": "growthcraft_cellar:potion_wine"
   },
-  "color": "0x805C2F"
+  "color": "0xDF9C40"
 }

--- a/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_amber_ale.json
+++ b/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_amber_ale.json
@@ -23,5 +23,5 @@
   "bottle": {
     "item": "growthcraft_cellar:potion_ale"
   },
-  "color": "0xE5C7A2"
+  "color": "0xBC6633"
 }

--- a/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_amber_lager.json
+++ b/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_amber_lager.json
@@ -23,5 +23,5 @@
   "bottle": {
     "item": "growthcraft_cellar:potion_lager"
   },
-  "color": "0xE5C7A2"
+  "color": "0xAB5E2F"
 }

--- a/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_brown_ale.json
+++ b/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_brown_ale.json
@@ -23,5 +23,5 @@
   "bottle": {
     "item": "growthcraft_cellar:potion_ale"
   },
-  "color": "0x594732"
+  "color": "0x5C311A"
 }

--- a/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_copper_ale.json
+++ b/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_copper_ale.json
@@ -23,5 +23,5 @@
   "bottle": {
     "item": "growthcraft_cellar:potion_ale"
   },
-  "color": "0x936B53"
+  "color": "0x8E4B31"
 }

--- a/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_copper_lager.json
+++ b/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_copper_lager.json
@@ -23,5 +23,5 @@
   "bottle": {
     "item": "growthcraft_cellar:potion_lager"
   },
-  "color": "0x936B53"
+  "color": "0x6F3D1F"
 }

--- a/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_ipa_ale.json
+++ b/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_ipa_ale.json
@@ -23,5 +23,5 @@
   "bottle": {
     "item": "growthcraft_cellar:potion_ale"
   },
-  "color": "0xF6D02E"
+  "color": "0xD2BD2C"
 }

--- a/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_old_port_ale.json
+++ b/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_old_port_ale.json
@@ -23,5 +23,5 @@
   "bottle": {
     "item": "growthcraft_cellar:potion_ale"
   },
-  "color": "0x805C2F"
+  "color": "0x8E3616"
 }

--- a/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_pale_lager.json
+++ b/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_pale_lager.json
@@ -23,5 +23,5 @@
   "bottle": {
     "item": "growthcraft_cellar:potion_lager"
   },
-  "color": "0xFBF855"
+  "color": "0xF3F33F"
 }

--- a/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_purple_wine.json
+++ b/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_purple_wine.json
@@ -23,5 +23,5 @@
   "bottle": {
     "item": "growthcraft_cellar:potion_wine"
   },
-  "color": "0x805C2F"
+  "color": "0x562251"
 }

--- a/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_red_wine.json
+++ b/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_red_wine.json
@@ -23,5 +23,5 @@
   "bottle": {
     "item": "growthcraft_cellar:potion_wine"
   },
-  "color": "0x805C2F"
+  "color": "0x8A343D"
 }

--- a/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_viena_lager.json
+++ b/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_viena_lager.json
@@ -23,5 +23,5 @@
   "bottle": {
     "item": "growthcraft_cellar:potion_lager"
   },
-  "color": "0xCFA26F"
+  "color": "0x904730"
 }

--- a/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_white_wine.json
+++ b/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_white_wine.json
@@ -23,5 +23,5 @@
   "bottle": {
     "item": "growthcraft_cellar:potion_wine"
   },
-  "color": "0x805C2F"
+  "color": "0x96A817"
 }

--- a/src/main/resources/data/growthcraft_rice/recipe/fermentation_barrel_rice_wine.json
+++ b/src/main/resources/data/growthcraft_rice/recipe/fermentation_barrel_rice_wine.json
@@ -23,5 +23,5 @@
   "bottle": {
     "item": "growthcraft_cellar:potion_wine"
   },
-  "color": "0xEAA6D2"
+  "color": "0xD9DADB"
 }

--- a/src/main/resources/data/growthcraft_rice/recipe/fermentation_barrel_sake.json
+++ b/src/main/resources/data/growthcraft_rice/recipe/fermentation_barrel_sake.json
@@ -23,5 +23,5 @@
   "bottle": {
     "item": "growthcraft_cellar:potion_wine"
   },
-  "color": "0xE0E2DC"
+  "color": "0xEAECEC"
 }


### PR DESCRIPTION
﻿## Summary
- correct fermentation recipe tint values for 16 drinks across Cellar, Apples, Apiary, and Rice
- align each recipe's filled-container color with the registered result fluid color
- leave effects, ingredients, outputs, and processing times unchanged

## Corrected drinks
Amber Ale, Amber Lager, Brown Ale, Copper Ale, Copper Lager, IPA Ale, Old Port Ale, Pale Lager, Purple Grape Wine, Red Grape Wine, White Grape Wine, Vienna Lager, Apple Cider, Honey Mead, Rice Wine, and Sake.

## Root cause
Several recipe colors were copied from their input wort or must. The three grape wines, for example, all used the same brown value instead of their distinct result-fluid colors.

## Validation
- `./gradlew.bat test --tests growthcraft.test.RecipeResourceTest --tests growthcraft.test.RecipeRuntimeCatalogTest -x createMinecraftArtifacts`
- `./gradlew.bat test -x createMinecraftArtifacts`
- parsed all fermentation recipe JSON files
- `git diff --check`
- manually inspected representative wine output colors in game/JEI

Closes #197
