### PR TITLE
Restore balanced Kumis fermentation

### DIFF
--- a/src/main/java/growthcraft/cellar/block/FermentationBarrelBlock.java
+++ b/src/main/java/growthcraft/cellar/block/FermentationBarrelBlock.java
@@ -1,6 +1,8 @@
 package growthcraft.cellar.block;
 
 import growthcraft.cellar.block.entity.FermentationBarrelBlockEntity;
+import growthcraft.milk.init.GrowthcraftMilkFluids;
+import growthcraft.milk.item.GrowthcraftMilkBucketItem;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.Containers;
@@ -10,6 +12,7 @@ import net.minecraft.world.ItemInteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BottleItem;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
@@ -31,6 +34,8 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.neoforged.neoforge.fluids.FluidUtil;
+import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 import org.jetbrains.annotations.Nullable;
 
 public class FermentationBarrelBlock extends Block implements EntityBlock {
@@ -85,6 +90,10 @@ public class FermentationBarrelBlock extends Block implements EntityBlock {
 
     @Override
     protected ItemInteractionResult useItemOn(ItemStack heldStack, BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hitResult) {
+        if (tryMilkBucketInteraction(heldStack, level, pos, player, hand)) {
+            return ItemInteractionResult.sidedSuccess(level.isClientSide);
+        }
+
         if (heldStack.getItem() instanceof BottleItem) {
             BlockEntity blockEntity = level.getBlockEntity(pos);
             if (blockEntity instanceof FermentationBarrelBlockEntity barrel && !barrel.getResultingPotionItemStack().isEmpty()) {
@@ -99,6 +108,26 @@ public class FermentationBarrelBlock extends Block implements EntityBlock {
             return ItemInteractionResult.sidedSuccess(level.isClientSide);
         }
         return ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
+    }
+
+    private static boolean tryMilkBucketInteraction(ItemStack heldStack, Level level, BlockPos pos, Player player, InteractionHand hand) {
+        boolean vanillaMilk = heldStack.is(Items.MILK_BUCKET);
+        boolean growthcraftMilk = heldStack.getItem() instanceof GrowthcraftMilkBucketItem;
+        if (!vanillaMilk && !growthcraftMilk) {
+            return false;
+        }
+
+        if (!level.isClientSide && level.getBlockEntity(pos) instanceof FermentationBarrelBlockEntity barrel) {
+            int filled = barrel.getTank().fill(new FluidStack(GrowthcraftMilkFluids.MILK.source.get(), 1000),
+                    IFluidHandler.FluidAction.EXECUTE);
+            if (filled == 1000 && !player.getAbilities().instabuild) {
+                ItemStack remainder = vanillaMilk
+                        ? new ItemStack(Items.BUCKET)
+                        : heldStack.getCraftingRemainingItem();
+                player.setItemInHand(hand, remainder);
+            }
+        }
+        return true;
     }
 
     private void fillBottleFromBarrel(BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, ItemStack heldStack, FermentationBarrelBlockEntity barrel) {

--- a/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_kumis.json
+++ b/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_kumis.json
@@ -1,10 +1,5 @@
 {
   "type": "growthcraft_cellar:fermentation_barrel_recipe",
-  "neoforge:conditions": [
-    {
-      "type": "neoforge:false"
-    }
-  ],
   "processing_time": 1200,
   "ingredient_item": {
     "item": "growthcraft_cellar:yeast_brewers",
@@ -21,8 +16,8 @@
   "effects": [
     {
       "effect": "minecraft:resistance",
-      "duration": 3600,
-      "amplifier": 1
+      "duration": 6000,
+      "amplifier": 0
     }
   ],
   "bottle": {


### PR DESCRIPTION
﻿## Summary
- re-enable the disabled Kumis Fermentation Barrel recipe
- balance Kumis as Resistance I for five minutes
- accept both vanilla and Growthcraft milk buckets in the Fermentation Barrel
- return the corresponding empty bucket after a successful 1,000 mB transfer

## Root cause
Kumis remained disabled after its old invalid output ID was corrected during porting. The current Kumis fluid is registered under `growthcraft_milk`, but the Fermentation Barrel's generic fluid interaction does not accept vanilla or Growthcraft milk buckets, leaving the restored recipe inaccessible through normal play.

Kumis previously duplicated Pilsner Lager's Resistance II for three minutes despite skipping the lager's grain roasting and wort-brewing stages. Resistance I for five minutes gives the lower-effort drink a useful but distinct role.

## Validation
- recipe and translation JSON parsing
- `./gradlew.bat test --tests growthcraft.test.RecipeResourceTest --tests growthcraft.test.RecipeRuntimeCatalogTest -x createMinecraftArtifacts`
- `./gradlew.bat compileJava -x createMinecraftArtifacts`
- `./gradlew.bat test -x createMinecraftArtifacts`
- `git diff --check`
- confirmed the recipe appears correctly in JEI
- confirmed milk can be inserted and the Kumis recipe completes in game
- confirmed the runtime Kumis translation resolves after resource reload

Closes #195
