### PR TITLE
Replace Stout hero effect with fire resistance

### DIFF
--- a/src/main/resources/assets/growthcraft/patchouli_books/growthcraft/en_us/entries/cellar/ales_and_lagers.json
+++ b/src/main/resources/assets/growthcraft/patchouli_books/growthcraft/en_us/entries/cellar/ales_and_lagers.json
@@ -10,7 +10,7 @@
     },
     {
       "type": "patchouli:text",
-      "text": "1. Grow wheat (or similar).$(br)2. Make a grain mixture; you can mix grain types. $(br)3. Roast the grain at the correct level in the $(l:cellar/roaster)Roaster$().$(br)4. Place the roasted grain with water in the $(l:cellar/brew_kettle)Brew Kettle$(). $(br)5. Place the resulting wort into a $(l:cellar/ferment_barrel)Fermentation Barrel$() with $(6)Brewer's$() or $(6)Lager yeast$(). $(br)6. Use a glass bottle to draw out the fermented fluid. $(br)7. Enjoy the effects$(br2)The following pages list the ingredients and effects of specific ales and lagers."
+      "text": "1. Grow wheat.$(br)2. Craft the wheat into Grain.$(br)3. Roast the Grain at the correct level in the $(l:cellar/roaster)Roaster$().$(br)4. Place the roasted Grain with water in the $(l:cellar/brew_kettle)Brew Kettle$().$(br)5. Place the resulting wort into a $(l:cellar/ferment_barrel)Fermentation Barrel$() with $(6)Brewer's$() or $(6)Lager Yeast$().$(br)6. Use a glass bottle to draw out the fermented fluid.$(br)7. Enjoy the effects.$(br2)The following pages list the ingredients and effects of specific ales and lagers."
     },
     {
       "type": "patchouli:spotlight",
@@ -21,7 +21,7 @@
     {
       "type": "patchouli:text",
       "title": "Ales (cont.)",
-      "text": "$(bold)IPA$() (from $(t:requires Golden Roasted Grain and Hops)$(o)Hopped Golden Wort*$())$(li)$(o)infused with extra $(2)Hops$()$(li)Jump Boost II (3:00)$(br2)$(bold)Old Port Ale$() (from $(t:requires Deep Copper Roasted Grain)$(o)Deep Copper Wort$())$(li)Luck (5:00)$(br2)$(bold)Pale Ale$() (from $(t:requires Pale Golden Roasted Grain)$(o)Pale Golden Wort$())$(li)Haste II (3:00)$(bold)$(br2)Stout Ale$() (from $(t:requires Dark Roasted Grain)$(o)Dark Wort$())$(li)Hero of the Village (10:00)"
+      "text": "$(bold)IPA$() (from $(t:requires Golden Roasted Grain and Hops)$(o)Hopped Golden Wort*$())$(li)$(o)infused with extra $(2)Hops$()$(li)Jump Boost II (3:00)$(br2)$(bold)Old Port Ale$() (from $(t:requires Deep Copper Roasted Grain)$(o)Deep Copper Wort$())$(li)Luck (5:00)$(br2)$(bold)Pale Ale$() (from $(t:requires Pale Golden Roasted Grain)$(o)Pale Golden Wort$())$(li)Haste II (3:00)$(bold)$(br2)Stout Ale$() (from $(t:requires Dark Roasted Grain)$(o)Dark Wort$())$(li)Fire Resistance (3:00)"
     },
     {
       "type": "patchouli:spotlight",

--- a/src/main/resources/assets/growthcraft/patchouli_books/growthcraft/en_us/entries/cellar/culture_jar.json
+++ b/src/main/resources/assets/growthcraft/patchouli_books/growthcraft/en_us/entries/cellar/culture_jar.json
@@ -10,6 +10,11 @@
       "text": "The culture jar is primarily used to multiply yeasts.$(br2)Put a yeast in a $(bold)Culture Jar$() with its $(l:cellar/yeast)corresponding fluid$(), provide a nearby heat source, and it will grow additional yeasts.$(br2)The culture jar is also used to grow a $(bold)Starter Culture$() for $(l:milk/making_cheese)Making Cheese$()."
     },
     {
+      "type": "patchouli:text",
+      "title": "Your First Culture",
+      "text": "Place Brewer's Yeast in a heated Culture Jar with 1,000 mB of Milk. After 4 minutes, it becomes Starter Culture.$(br2)$(bold)Multiplying Cultures$()$(br)Place an existing Starter Culture in the heated Culture Jar with 250 mB of Milk or Skim Milk. After 1 minute, an additional Starter Culture is produced."
+    },
+    {
       "type": "patchouli:crafting",
       "recipe": "growthcraft_cellar:culture_jar"
     }

--- a/src/main/resources/assets/growthcraft/patchouli_books/growthcraft/en_us/entries/cellar/yeast.json
+++ b/src/main/resources/assets/growthcraft/patchouli_books/growthcraft/en_us/entries/cellar/yeast.json
@@ -27,6 +27,12 @@
       "type": "patchouli:spotlight",
       "item": "growthcraft_cellar:yeast_ethereal",
       "text": "$(bold)Ethereal Yeast$() - These are magical versions of yeast, which do not have a purpose yet.$(br2)$(bold)Source$() - Ethereal yeast is not currently lootable in the world.$(br2)$(bold)Culturing$() - Needs generic Wort from wheat."
+    },
+    {
+      "type": "patchouli:spotlight",
+      "item": "growthcraft_milk:starter_culture",
+      "title": "Starter Culture",
+      "text": "$(bold)Starter Culture$() - Starter Culture is used to make cultured milk and other dairy products.$(br2)$(bold)Source$() - Create the first culture from Brewer's Yeast in a heated $(l:cellar/culture_jar)Culture Jar$().$(br2)$(bold)Culturing$() - Needs Milk or Skim Milk."
     }
   ]
 }

--- a/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_stout_ale.json
+++ b/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_stout_ale.json
@@ -15,9 +15,9 @@
   },
   "effects": [
     {
-      "effect": "minecraft:hero_of_the_village",
-      "duration": 12000,
-      "amplifier": 1
+      "effect": "minecraft:fire_resistance",
+      "duration": 6000,
+      "amplifier": 0
     }
   ],
   "bottle": {

--- a/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_stout_ale.json
+++ b/src/main/resources/data/growthcraft_cellar/recipe/fermentation_barrel_stout_ale.json
@@ -16,7 +16,7 @@
   "effects": [
     {
       "effect": "minecraft:fire_resistance",
-      "duration": 6000,
+      "duration": 3600,
       "amplifier": 0
     }
   ],


### PR DESCRIPTION
## Summary
- replace Stout Ale's Hero of the Village II effect with Fire Resistance I for three minutes
- keep the Stout ingredients, output, color, and fermentation processing time unchanged
- update the Ales and Lagers guide with the new Stout effect and clearer default grain instructions
- document Starter Culture in Yeast and Cultures and add the first-culture workflow to the Culture Jar chapter

## Rationale
Hero of the Village represents recognition for defending a village and does not make thematic sense as a portable fermented effect.

Stout requires roughly 11 minutes of machine processing and 12–15 minutes of practical player workflow for a one-bucket batch, which yields two drinks. A three-minute Fire Resistance effect matches the standard vanilla potion duration while attaching a substantially longer production cost to the early-game advantage.

## Validation
- manually confirmed the filled Stout applies Fire Resistance
- manually reviewed the updated Patchouli pages in game
- parsed the updated Patchouli JSON
- `./gradlew.bat test --tests growthcraft.test.RecipeResourceTest --tests growthcraft.test.RecipeRuntimeCatalogTest -x createMinecraftArtifacts`
- `./gradlew.bat test -x createMinecraftArtifacts`
- `git diff --check`

Closes #192