### PR TITLE
Picking up curds in mv gui

### DIFF
--- a/src/main/java/growthcraft/milk/block/entity/MixingVatBlockEntity.java
+++ b/src/main/java/growthcraft/milk/block/entity/MixingVatBlockEntity.java
@@ -330,6 +330,9 @@ public class MixingVatBlockEntity extends BlockEntity implements WorldlyContaine
 
     @Override
     public void setItem(int index, ItemStack stack) {
+        if (index == SLOT_RESULT && stack.isEmpty()) {
+            this.setItem(SLOT_RESULT_TOOL, ItemStack.EMPTY);
+        }
         items.set(index, stack);
         if (stack.getCount() > getMaxStackSize()) {
             stack.setCount(getMaxStackSize());

--- a/src/main/java/growthcraft/milk/item/CheeseCurdsBlockItem.java
+++ b/src/main/java/growthcraft/milk/item/CheeseCurdsBlockItem.java
@@ -1,9 +1,14 @@
 package growthcraft.milk.item;
 
 import growthcraft.milk.init.GrowthcraftMilkItems;
+import net.minecraft.world.entity.SlotAccess;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ClickAction;
+import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Block;
 
 public class CheeseCurdsBlockItem extends BlockItem {
@@ -19,5 +24,26 @@ public class CheeseCurdsBlockItem extends BlockItem {
     @Override
     public boolean hasCraftingRemainingItem(ItemStack stack) {
         return true;
+    }
+
+    @Override
+    public boolean overrideOtherStackedOnMe(ItemStack stack, ItemStack other, Slot slot, ClickAction action, Player player, SlotAccess access)
+    {
+        if (slot.mayPickup(player) || slot.isFake()) {
+            return false;  // in chest or in player's inventory
+        }
+        if (other.is(GrowthcraftMilkItems.CHEESE_CLOTH) && action.equals(ClickAction.SECONDARY))
+        {
+            if (other.getCount() > 1 && ! player.isLocalPlayer()) {
+                ItemStack toGive = other.copyWithCount(other.getCount() - 1);
+                if (!player.addItem(toGive)) {
+                    player.drop(toGive, false);
+                }
+            }
+            access.set(slot.getItem().copy());
+            slot.set(ItemStack.EMPTY);
+            return true;
+        }
+        return super.overrideOtherStackedOnMe(stack, other, slot, action, player, access);
     }
 }

--- a/src/main/java/growthcraft/milk/recipe/MixingVatRecipe.java
+++ b/src/main/java/growthcraft/milk/recipe/MixingVatRecipe.java
@@ -3,6 +3,7 @@ package growthcraft.milk.recipe;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import growthcraft.milk.block.entity.MixingVatBlockEntity;
 import growthcraft.milk.init.GrowthcraftMilkRecipes;
 import growthcraft.milk.recipe.input.MixingVatInput;
 import net.minecraft.core.HolderLookup;
@@ -157,7 +158,8 @@ public class MixingVatRecipe implements Recipe<MixingVatInput> {
         boolean[] used = new boolean[input.size()];
         for (IngredientStack required : ingredients) {
             boolean matched = false;
-            for (int i = 0; i < input.size(); i++) {
+            int limit = Math.min(input.size(), MixingVatBlockEntity.SLOT_RESULT);
+            for (int i = 0; i < limit; i++) {
                 if (!used[i] && required.matches(input.getItem(i))) {
                     used[i] = true;
                     matched = true;


### PR DESCRIPTION
I allowed cheese cloth to pick up cheese curds in MV in the same manner a leather bundle would pick up anything. (and no, bundle can not cheat out curds)

If we have a gui, and we see a slot, no reason not to take things from it. 

In-world functionality (clicking MV with cloth) intact.

One change in recipe class is not necessary for this functionality; it was a wrong logic that wasn't doing wrong recipe matching... yet.