### PR TITLE
Fix fermented drink name styling

### DIFF
--- a/src/main/java/growthcraft/cellar/recipe/FermentationBarrelRecipe.java
+++ b/src/main/java/growthcraft/cellar/recipe/FermentationBarrelRecipe.java
@@ -94,7 +94,7 @@ public class FermentationBarrelRecipe implements Recipe<FermentationBarrelInput>
 
         var fluid = BuiltInRegistries.FLUID.get(result.fluidId());
         if (fluid != Fluids.EMPTY) {
-            stack.set(DataComponents.CUSTOM_NAME,
+            stack.set(DataComponents.ITEM_NAME,
                     new FluidStack(fluid, Math.max(1, result.amount())).getHoverName());
         }
 

--- a/src/test/java/growthcraft/cellar/recipe/FermentationBarrelRecipeNameTest.java
+++ b/src/test/java/growthcraft/cellar/recipe/FermentationBarrelRecipeNameTest.java
@@ -1,0 +1,27 @@
+package growthcraft.cellar.recipe;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FermentationBarrelRecipeNameTest {
+    private static final Path RECIPE_SOURCE =
+            Path.of("src/main/java/growthcraft/cellar/recipe/FermentationBarrelRecipe.java");
+
+    @Test
+    void bottleUsesFluidItemNameWithoutCreatingCustomName() throws IOException {
+        String source = Files.readString(RECIPE_SOURCE);
+        int methodStart = source.indexOf("private static ItemStack createBottleStack");
+        int nextMethod = source.indexOf("private static Optional<MobEffectInstance>", methodStart);
+        String createBottleStack = source.substring(methodStart, nextMethod);
+
+        assertTrue(createBottleStack.contains("DataComponents.ITEM_NAME"));
+        assertFalse(createBottleStack.contains("DataComponents.CUSTOM_NAME"));
+        assertTrue(createBottleStack.contains("DataComponents.POTION_CONTENTS"));
+    }
+}


### PR DESCRIPTION
## Summary

- store fluid-derived fermentation output names in `DataComponents.ITEM_NAME`
- preserve potion contents, drink colors, effects, and translated fluid names
- add regression coverage preventing fermentation outputs from reverting to `CUSTOM_NAME`

## Root cause

`FermentationBarrelRecipe.createBottleStack()` stored the fluid hover name as `DataComponents.CUSTOM_NAME`. Minecraft treats that component as a player/anvil-assigned name and renders it in italics. These generated drink names are intrinsic item names, so they belong in `DataComponents.ITEM_NAME`.

## User impact

Wine bottles, ale pints, and lager pints retain their correct fluid-specific names without displaying those names in italics.

## Validation

- pre-fix operational reproduction confirmed the italic custom-name styling
- `./gradlew.bat test --tests growthcraft.cellar.recipe.FermentationBarrelRecipeNameTest`
- `./gradlew.bat test`
- `./gradlew.bat build`
- datagen completed without resource changes
- `git diff --check`

Post-fix operational validation is pending.

Closes #216
